### PR TITLE
Fix for issue 45 http://code.google.com/p/google-sitebricks/issues/detail?id=45

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
@@ -63,6 +63,7 @@ class HiddenMethodFilter implements Filter {
       httpRequest.setAttribute(filterDoneAttributeName, Boolean.TRUE);
 
       try {
+    	HttpServletRequestWrapper originalRequest = new HttpServletRequestWrapper(httpRequest);
         String methodName = httpRequest.getParameter(this.hiddenFieldName);
 
         if ("POST".equalsIgnoreCase(httpRequest.getMethod()) && !Strings.empty(methodName)) {
@@ -72,7 +73,7 @@ class HiddenMethodFilter implements Filter {
         } else {
 
           // Filtering done, forward to another filter in chain
-          filterChain.doFilter(httpRequest, response);
+          filterChain.doFilter(originalRequest, response);
         }
       } finally {
         // Remove the filterDone attribute for this request.


### PR DESCRIPTION
In the hidden method filter we wrap the original request before trying to read the parameter, if the parameter is not found we return the original (wrapped) request and not the one for which we have consumed the input stream. This will fix issue 45 http://code.google.com/p/google-sitebricks/issues/detail?id=45
