### PR TITLE
Decorated Pages with Guice Stage.PRODUCTION are not Precompiled

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/ScanAndCompileBootstrapper.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/ScanAndCompileBootstrapper.java
@@ -115,12 +115,14 @@ class ScanAndCompileBootstrapper implements Bootstrapper {
   }
 
   private void extendedPages(Set<Page> pagesToCompile) {
+    Set<Page> pageExtensions = Sets.newHashSet();
     for (Page page : pagesToCompile) {
       if (page.pageClass().isAnnotationPresent(Decorated.class)) {
         // recursively add extension pages
-        analyseExtension(pagesToCompile, page.pageClass());
+        analyseExtension(pageExtensions, page.pageClass());
       }
     }
+    pagesToCompile.addAll(pageExtensions);
   }
 
   //processes all explicit bindings, including static resources.
@@ -206,8 +208,9 @@ class ScanAndCompileBootstrapper implements Bootstrapper {
     return pagesToCompile;
   }
 
-  private void analyseExtension(Set<PageBook.Page> pagesToCompile, Class<?> extendClass) {
+  private void analyseExtension(Set<PageBook.Page> pagesToCompile, final Class<?> extendClassArgument) {
     // store the page with a special page name used by ExtendWidget
+    Class<?> extendClass = extendClassArgument;
     pagesToCompile.add(pageBook.decorate(extendClass));
     
     // recursively analyse super class
@@ -221,7 +224,7 @@ class ScanAndCompileBootstrapper implements Bootstrapper {
         return;
       }
     }
-    throw new IllegalStateException("Could not find super class annotated with @Show");
+    throw new IllegalStateException("Could not find super class annotated with @Show on parent of class: " + extendClassArgument);
   }
 
   private void compilePages(Set<PageBook.Page> pagesToCompile) {

--- a/sitebricks/src/main/java/com/google/sitebricks/routing/DefaultPageBook.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/routing/DefaultPageBook.java
@@ -1,5 +1,24 @@
 package com.google.sitebricks.routing;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
@@ -25,22 +44,6 @@ import com.google.sitebricks.http.negotiate.ContentNegotiator;
 import com.google.sitebricks.http.negotiate.Negotiation;
 import com.google.sitebricks.rendering.Strings;
 import com.google.sitebricks.rendering.control.DecorateWidget;
-import net.jcip.annotations.GuardedBy;
-import net.jcip.annotations.ThreadSafe;
-import org.jetbrains.annotations.Nullable;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * contains active uri/widget mappings
@@ -597,13 +600,20 @@ public class DefaultPageBook implements PageBook {
 
       Page that = (Page) o;
 
-      return this.clazz.equals(that.pageClass());
+      return this.clazz.equals(that.pageClass()) && isDecorated() == that.isDecorated();
     }
 
     @Override
     public int hashCode() {
       return clazz.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(PageTuple.class).add("clazz", clazz).add("isDecorated", extension)
+                .add("uri", uri).toString();
+    }
+
   }
 
   private static class MethodTuple implements Action {


### PR DESCRIPTION
When I switched to Stage.PRODUCTION I found that the DebugPageBook (and how it recompiles upon each request) was masking an issue:
- The DefaultPageBook.PageTuple.equals method did not take into account the isDecorated flag, so no decorated pages were added to the pagesToCompile of the ScanAndCompileBootstrapper
- The ScanAndCompileBootStrapper.extendedPages method was trying to add elements to the Set that it is iterating over

This was discussed here: http://groups.google.com/group/google-sitebricks/browse_thread/thread/4ca57a97a8a31246
