### PR TITLE
Fix for issue 45 http://code.google.com/p/google-sitebricks/issues/detail?id=45

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
@@ -83,7 +83,7 @@ class HiddenMethodFilter implements Filter {
           // Making the input stream available again fix for issue 45
           wrappedRequest = getWrappedRequest(httpRequest, reqBytes);
           //Filtering done, forward to another filter in chain
-          filterChain.doFilter(httpRequest, response);
+          filterChain.doFilter(wrappedRequest, response);
         }
       } finally {
         // Remove the filterDone attribute for this request.

--- a/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/HiddenMethodFilter.java
@@ -9,10 +9,13 @@ import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Locale;
 
@@ -63,15 +66,23 @@ class HiddenMethodFilter implements Filter {
       httpRequest.setAttribute(filterDoneAttributeName, Boolean.TRUE);
 
       try {
-        String methodName = httpRequest.getParameter(hiddenFieldName);
+        ServletInputStream inputStream = httpRequest.getInputStream();
+        byte[] reqBytes = new byte[httpRequest.getContentLength()];
+        inputStream.read(reqBytes);
+
+        // Making the input stream available again because we have
+        // already read bytes
+        HttpServletRequestWrapper wrappedRequest = getWrappedRequest(httpRequest, reqBytes);
+        String methodName = wrappedRequest.getParameter(this.hiddenFieldName);
 
         if ("POST".equalsIgnoreCase(httpRequest.getMethod()) && !Strings.empty(methodName)) {
           String methodNameUppercase = methodName.toUpperCase(Locale.ENGLISH);
           HttpServletRequest wrapper = new HttpMethodRequestWrapper(methodNameUppercase, httpRequest);
           filterChain.doFilter(wrapper, response);
         } else {
-
-          // Filtering done, forward to another filter in chain
+          // Making the input stream available again fix for issue 45
+          wrappedRequest = getWrappedRequest(httpRequest, reqBytes);
+          //Filtering done, forward to another filter in chain
           filterChain.doFilter(httpRequest, response);
         }
       } finally {
@@ -79,6 +90,26 @@ class HiddenMethodFilter implements Filter {
         request.removeAttribute(filterDoneAttributeName);
       }
     }
+  }
+  
+  private HttpServletRequestWrapper getWrappedRequest(HttpServletRequest httpRequest, final byte[] reqBytes)
+       throws IOException {
+
+    final ByteArrayInputStream byteInput = new ByteArrayInputStream(reqBytes);
+    return new HttpServletRequestWrapper(httpRequest) {
+     
+      @Override
+      public ServletInputStream getInputStream() throws IOException {
+        ServletInputStream sis = new ServletInputStream() {
+
+          @Override
+          public int read() throws IOException {
+            return byteInput.read();
+          }
+        };
+        return sis;
+      }
+    };
   }
 
   public void destroy() {


### PR DESCRIPTION
In the hidden method filter we wrap the original request before trying to read the parameter, if the parameter is not found we return the original (wrapped) request and not the one for which we have consumed the input stream. This will fix issue 45 http://code.google.com/p/google-sitebricks/issues/detail?id=45