### PR TITLE
Really Pluggable Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 *.ipr
 *.iws
 *.iml
+atlassian-ide-plugin.xml
 
 # Eclipse
 .classpath

--- a/pom.atom
+++ b/pom.atom
@@ -1,7 +1,7 @@
 repositories << "http://scala-tools.org/repo-releases/"
 
 project "Sitebricks :: Parent" @ "https://github.com/dhanji/sitebricks"
-  id: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT
+  id: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT
   inherit: org.sonatype.oss:oss-parent:6
   packaging: pom
 

--- a/sitebricks-acceptance-tests/pom.atom
+++ b/sitebricks-acceptance-tests/pom.atom
@@ -1,8 +1,8 @@
 repositories << "http://nexus.openqa.org/content/repositories/releases,http://repository.codehaus.org"
 
 project "Sitebricks :: Acceptance Tests" @ "null"
-  id: com.google.sitebricks:sitebricks-acceptance-tests:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-acceptance-tests:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   overrides: [ org.slf4j:slf4j-api:1.6.1 ]

--- a/sitebricks-client/pom.atom
+++ b/sitebricks-client/pom.atom
@@ -1,6 +1,6 @@
 project "Sitebricks :: Client" @ "null"
-  id: com.google.sitebricks:sitebricks-client:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-client:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.testng:testng:${org.testng.version}(jdk15)

--- a/sitebricks-converter/pom.atom
+++ b/sitebricks-converter/pom.atom
@@ -1,6 +1,6 @@
 project "Sitebricks :: Type Conversion" @ "null"
-  id: com.google.sitebricks:sitebricks-converter:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-converter:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.testng:testng:${org.testng.version}(jdk15)

--- a/sitebricks-easy-client/META-INF/MANIFEST.MF
+++ b/sitebricks-easy-client/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
-Export-Package: org.sitebricks.client.easy;version="0.8.6.SNAPSHOT";
+Export-Package: org.sitebricks.client.easy;version="0.8.7.SNAPSHOT";
   uses:="com.google.inject.binder,
    com.google.inject.util,
    org.sonatype.sisu.sitebricks.client.internal,
    com.google.inject",
- org.sitebricks.client.easy.internal;version="0.8.6.SNAPSHOT";
+ org.sitebricks.client.easy.internal;version="0.8.7.SNAPSHOT";
   uses:="com.google.sitebricks.client,
    com.google.sitebricks.http,
    com.google.sitebricks.client.transport,
@@ -17,7 +17,7 @@ Export-Package: org.sitebricks.client.easy;version="0.8.6.SNAPSHOT";
    org.sonatype.sisu.sitebricks.client,
    com.google.inject.spi,
    com.google.inject"
-Bundle-Version: 0.8.6.SNAPSHOT
+Bundle-Version: 0.8.7.SNAPSHOT
 Tool: Bnd-0.0.357
 Bundle-Name: sitebricks-easy-client
 Bnd-LastModified: 1327256671731
@@ -41,4 +41,3 @@ Import-Package: com.google.inject;version="1.3",
  org.codehaus.jackson.type;version="1.9",
  org.sitebricks.client.easy;version="0.8",
  org.sitebricks.client.easy.internal;version="0.8"
-

--- a/sitebricks-easy-client/pom.xml
+++ b/sitebricks-easy-client/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/sitebricks-jetty-archetype/pom.atom
+++ b/sitebricks-jetty-archetype/pom.atom
@@ -1,6 +1,6 @@
 project "Sitebricks :: Jetty Archetype" @ "null"
-  id: com.google.sitebricks:sitebricks-jetty-archetype:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-jetty-archetype:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ com.google.sitebricks:sitebricks

--- a/sitebricks-jetty-archetype/src/main/resources/archetype-resources/src/main/java/Main.java
+++ b/sitebricks-jetty-archetype/src/main/resources/archetype-resources/src/main/java/Main.java
@@ -13,6 +13,7 @@ import org.mortbay.jetty.webapp.WebAppContext;
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
  */
 public class Main {
+
   private static final int PORT = 8080;
 
   public static void main(String... args) throws Exception {

--- a/sitebricks-mail/pom.atom
+++ b/sitebricks-mail/pom.atom
@@ -1,10 +1,10 @@
 project "Sitebricks :: Mail Client" @ "null"
-  id: com.google.sitebricks:sitebricks-mail:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-mail:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.apache.james:apache-mime4j:0.6
-               com.google.sitebricks:sitebricks:0.8.6-SNAPSHOT
+               com.google.sitebricks:sitebricks:0.8.7-SNAPSHOT
                org.jboss.netty:netty:3.2.4.Final
                org.slf4j:slf4j-api:1.5.5
                ch.qos.logback:logback-classic:${ch.qos.logback.version}

--- a/sitebricks-options/pom.atom
+++ b/sitebricks-options/pom.atom
@@ -1,8 +1,8 @@
 repositories << "http://repository.jboss.org/nexus/content/groups/public-jboss/"
 
 project "Sitebricks :: Options Module" @ "null"
-  id: com.google.sitebricks:sitebricks-options:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-options:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ com.google.sitebricks:sitebricks-converter

--- a/sitebricks/pom.atom
+++ b/sitebricks/pom.atom
@@ -1,6 +1,6 @@
 project "Sitebricks :: Core" @ "null"
-  id: com.google.sitebricks:sitebricks:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.testng:testng:${org.testng.version}(jdk15)

--- a/sitebricks/src/main/java/com/google/sitebricks/DefaultTemplateSystem.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/DefaultTemplateSystem.java
@@ -1,10 +1,11 @@
 package com.google.sitebricks;
 
-import java.util.Map;
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.sitebricks.compiler.TemplateCompiler;
+
+import java.util.Map;
+import java.util.Set;
 
 @Singleton
 public class DefaultTemplateSystem implements TemplateSystem {
@@ -16,14 +17,27 @@ public class DefaultTemplateSystem implements TemplateSystem {
     this.templateCompilers = templateCompilers;
   }
 
+  @Override
   public TemplateCompiler compilerFor(String templateName) {
     String extension = templateName.substring(templateName.lastIndexOf(".") + 1);
-    TemplateCompiler templateCompiler = templateCompilers.get(extension);
-    return templateCompiler;    
+    return templateCompilers.get(extension);
   }
 
   @Override
   public String[] getTemplateExtensions() {
-    return new String[] { "%s.html", "%s.xhtml", "%s.xml", "%s.txt", "%s.fml", "%s.dml", "%s.mvel" };
-  }  
+    Set<String> keys = templateCompilers.keySet();
+
+    if (keys.isEmpty()) {
+      return new String[0];
+    }
+
+    String[] extensions = new String[keys.size()];
+
+    int i = 0;
+    for (String ext : keys) {
+      extensions[i++] = "%s." + ext;
+    }
+
+    return extensions;
+  }
 }

--- a/sitebricks/src/main/java/com/google/sitebricks/SitebricksModule.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/SitebricksModule.java
@@ -62,9 +62,9 @@ public class SitebricksModule extends AbstractModule implements PageBinder {
     methods.put("delete", Delete.class);
     methods.put("head", Head.class);
     methods.put("trace", Trace.class);
-    
+
   }
-  
+
   @Override
   protected final void configure() {
 
@@ -117,19 +117,29 @@ public class SitebricksModule extends AbstractModule implements PageBinder {
 
     configureTemplateSystem();
   }
-  
-  protected void configureTemplateSystem() {    
+
+  protected void configureTemplateSystem() {
     //
     // Map of all the implementations keyed by type they can handle 
     //
     MapBinder<String,TemplateCompiler> templateCompilers = MapBinder.newMapBinder(binder(), String.class, TemplateCompiler.class);
     templateCompilers.addBinding("html").to(HtmlTemplateCompiler.class);
+    templateCompilers.addBinding("xhtml").to(HtmlTemplateCompiler.class);
     templateCompilers.addBinding("xml").to(XmlTemplateCompiler.class);
     templateCompilers.addBinding("flat").to(FlatTemplateCompiler.class);
     templateCompilers.addBinding("mvel").to(MvelTemplateCompiler.class);
-    templateCompilers.addBinding("fml").to(FreemarkerTemplateCompiler.class);    
+    templateCompilers.addBinding("fml").to(FreemarkerTemplateCompiler.class);
+
+    configureTemplateCompilers(templateCompilers);
   }
-  
+
+  protected void configureTemplateCompilers(MapBinder<String, TemplateCompiler> compilers) {
+    // Override to include custom template compilers. You can also simply add to the existing MapBinder
+    // mapping anywhere in your modules (see: http://code.google.com/p/google-guice/wiki/Multibindings):
+    //  MapBinder<String,TemplateCompiler> templateCompilers = MapBinder.newMapBinder(binder(), String.class, TemplateCompiler.class);
+    //  templateCompilers.addBinding("mustache").to(MustacheTemplateCompiler.class);
+  }
+
   /**
    * Optionally supply {@link javax.servlet.Servlet} and/or {@link javax.servlet.Filter} implementations to
    * Guice Servlet. See {@link com.google.sitebricks.SitebricksServletModule} for usage examples.
@@ -194,7 +204,7 @@ public class SitebricksModule extends AbstractModule implements PageBinder {
       public void using(Locale locale, Properties properties) {
         Preconditions.checkArgument(null != properties, "Must provide a non-null resource bundle");
         // A Properties object is always of type string/string
-        @SuppressWarnings({ "unchecked", "rawtypes" }) 
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         Map<String, String> messages = (Map) properties;
         localizations.add(new Localizer.Localization(iface, locale, messages));
       }
@@ -221,7 +231,7 @@ public class SitebricksModule extends AbstractModule implements PageBinder {
     Preconditions.checkArgument(null != pack, "Package parameter to scan() cannot be null");
     packages.add(pack);
   }
-  
+
   static enum BindingKind {
     EMBEDDED, PAGE, SERVICE, STATIC_RESOURCE, ACTION
   }
@@ -331,20 +341,20 @@ public class SitebricksModule extends AbstractModule implements PageBinder {
       this.asEagerSingleton = true;
     }
   }
-  
+
   //
   // Converters
   //
-  
+
   @SuppressWarnings("rawtypes")
   private Multibinder<Converter> converters;
-  
+
   public final void converter(Converter<?, ?> converter)    {
     Preconditions.checkArgument(null != converter, "Type converters cannot be null");
     converters.addBinding().toInstance(converter);
   }
-  
+
   public final void converter(Class<? extends Converter<?, ?>> clazz) {
     converters.addBinding().to(clazz);
-  }  
+  }
 }

--- a/sitebricks/src/main/java/com/google/sitebricks/TemplateLoader.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/TemplateLoader.java
@@ -1,101 +1,175 @@
 package com.google.sitebricks;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.sitebricks.compiler.TemplateCompiler;
+
+import net.jcip.annotations.Immutable;
+
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
+import java.util.Arrays;
 
 import javax.servlet.ServletContext;
-
-import net.jcip.annotations.Immutable;
-
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.sitebricks.compiler.TemplateCompiler;
-import com.google.sitebricks.rendering.control.WidgetRegistry;
-import com.google.sitebricks.routing.PageBook;
-import com.google.sitebricks.routing.SystemMetrics;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
  */
 @Immutable
 public class TemplateLoader {
-  
+
   private final Provider<ServletContext> context;
   private final TemplateSystem templateSystem;
-  
+
   @Inject
-  public TemplateLoader(WidgetRegistry registry, PageBook pageBook, SystemMetrics metrics, Provider<ServletContext> context, TemplateSystem templateSystem) {
+  public TemplateLoader(Provider<ServletContext> context, TemplateSystem templateSystem) {
     this.context = context;
     this.templateSystem = templateSystem;
   }
 
   public Template load(Class<?> pageClass) {
     //
-	  // try to find the template name
+    // try to find the template name
     //
-    Show show = pageClass.getAnnotation(Show.class);
     String template = null;
+    String extension = null;
+
+    Show show = pageClass.getAnnotation(Show.class);
     if (null != show) {
       template = show.value();
     }
-    
+
     //
     // an empty string means no template name was given
     //
     if (template == null || template.length() == 0) {
       // use the default name for the page class
-      template = resolve(pageClass);
+      template = pageClass.getSimpleName();
+    } else {
+      // Check and see if the supplied template value has a supported file extension
+      for (String ext : templateSystem.getTemplateExtensions()) {
+        String type = ext.replace("%s.", ".");
+        if (template.endsWith(type)) {
+          extension = type;
+          break;
+        }
+      }
+    }
+
+    if (null == template) {
+      throw new MissingTemplateException(String.format("Could not determine the base template name for %s", Show.class));
     }
 
     TemplateSource templateSource = null;
-    
     String text;
+
     try {
+      final ServletContext servletContext = context.get();
       InputStream stream = null;
-      //      
-      //first look in class neighborhood for template
+
       //
-      if (null != template) {
+      // If there was a matching file extension, short-circuit the deep search
+      //
+
+      if (template.contains(".") || null != extension) {
+        // Check class neighborhood for direct match
         stream = pageClass.getResourceAsStream(template);
+
+        // Check url conventions for direct match
+        if (null == stream) {
+          stream = open(template, servletContext);
+        }
+
+        // Same as above, but checks in WEB-INF
+        if (null == stream) {
+          stream = openWebInf(template, servletContext);
+        }
+
+        // Finally, try to get the resource from the servlet context
+        if (null == stream) {
+          stream = servletContext.getResourceAsStream(template);
+        }
       }
 
       //
-      //look on the webapp resource path if not in classpath
+      // No direct match, so start hunting.
+      // First, look in class neighborhood for template
       //
+
       if (null == stream) {
+        for (String ext : templateSystem.getTemplateExtensions()) {
+          String name = String.format(ext, template);
 
-        final ServletContext servletContext = context.get();
-        if (null != template) {
-          stream = open(template, servletContext).resource;
-        }
+          stream = pageClass.getResourceAsStream(name);
 
-        //
-        //resolve again, but this time on the webapp resource path
-        //
-        if (null == stream) {
-          final ResolvedTemplate resolvedTemplate = resolve(pageClass, servletContext, template);
-          if (null != resolvedTemplate) {
-            template = resolvedTemplate.templateName;
-            stream = resolvedTemplate.resource;
-            templateSource = new FileTemplateSource(resolvedTemplate.templateFile);
+          if (null != stream) {
+            break;
           }
         }
+      }
 
-        //
-        //if there's still no template, then error out
-        //
-        if (null == stream) {
-          throw new MissingTemplateException(String.format("Could not find a suitable template for %s, " + "did you remember to place an @Show? None of [" +
-              templateSystem.getTemplateExtensions()[0] + "] could be found in either package [%s], in the root of the resource dir OR in WEB-INF/.",
-              pageClass.getName(), pageClass.getSimpleName(),
-              pageClass.getPackage().getName()));
+      //
+      // Check for qualified file paths in context
+      // TODO: I think this is redundant, but make sure before deleting
+      //
+
+      if (null == stream) {
+        for (String ext : templateSystem.getTemplateExtensions()) {
+          String name = String.format(ext, pageClass.getSimpleName());
+
+          stream = open(name, servletContext);
+
+          if (null != stream) {
+            break;
+          }
         }
+      }
+
+      //
+      // Same thing, but check in WEB-INF
+      //
+
+      if (null == stream) {
+        for (String ext : templateSystem.getTemplateExtensions()) {
+          String name = String.format(ext, pageClass.getSimpleName());
+
+          stream = openWebInf(name, servletContext);
+
+          if (null != stream) {
+            break;
+          }
+        }
+      }
+
+      //
+      // Finally, look in the ServletContext resource path if not in classpath
+      //
+
+      if (null == stream) {
+        for (String ext : templateSystem.getTemplateExtensions()) {
+          String name = String.format(ext, template);
+
+          stream = servletContext.getResourceAsStream(name);
+
+          if (null != stream) {
+            break;
+          }
+        }
+      }
+
+      //
+      //if there's still no template, then error out
+      //
+      if (null == stream) {
+        throw new MissingTemplateException(String.format(
+          "Could not find a suitable template for %s, did you remember to place an @Show? None of " +
+          Arrays.toString(templateSystem.getTemplateExtensions()).replace("%s.", ".")
+          + " could be found in either package [%s], in the root of the resource dir OR in WEB-INF/.",
+          pageClass.getName(), pageClass.getSimpleName(), pageClass.getPackage().getName()));
       }
 
       text = read(stream);
@@ -105,84 +179,18 @@ public class TemplateLoader {
 
     return new Template(template, text, templateSource);
   }
-  
-  private ResolvedTemplate resolve(Class<?> pageClass, ServletContext context, String template) {
-    //first resolve using url conversion
-    for (String nameTemplate : templateSystem.getTemplateExtensions()) {
-      String templateName = String.format(nameTemplate, pageClass.getSimpleName());
-      ResolvedTemplate resolvedTemplate = open(templateName, context);
 
-      if (null != resolvedTemplate.resource) {
-        return resolvedTemplate;
-      }
-
-      resolvedTemplate = openWebInf(templateName, context);
-
-      if (null != resolvedTemplate.resource) {
-        return resolvedTemplate;
-      }
-
-      if (null == template) {
-          continue;
-      }
-      //try to resolve @Show template from web-inf folder  
-      resolvedTemplate = openWebInf(template, context);
-
-      if (null != resolvedTemplate.resource) {
-          return resolvedTemplate;
-      }
-    }
-
-    //resolve again using servlet context if that fails
-    for (String nameTemplate : templateSystem.getTemplateExtensions()) {
-      String templateName = String.format(nameTemplate, pageClass.getSimpleName());
-      InputStream resource = context.getResourceAsStream(templateName);
-
-      if (null != resource) {
-        return new ResolvedTemplate(templateName, resource, null);
-      }
-    }
-
-    return null;
-  }
-
-  private static class ResolvedTemplate {
-    private final InputStream resource;
-    private final String templateName;
-    private final File templateFile;
-
-    private ResolvedTemplate(String templateName, InputStream resource, File templateFile) {
-      this.templateName = templateName;
-      this.resource = resource;
-      this.templateFile = templateFile;
-    }
-  }
-
-  private static ResolvedTemplate open(String templateName, ServletContext context) {
-    try {      
+  private static InputStream open(String templateName, ServletContext context) {
+    try {
       String path = context.getRealPath(templateName);
-      return path == null ? null : new ResolvedTemplate(templateName, new FileInputStream(path), new File(path));
+      return path == null ? null : new FileInputStream(path);
     } catch (FileNotFoundException e) {
-      return new ResolvedTemplate(templateName, null, null);
+      return null;
     }
   }
-  
-  private static ResolvedTemplate openWebInf(String templateName, ServletContext context) {
+
+  private static InputStream openWebInf(String templateName, ServletContext context) {
     return open("/WEB-INF/" + templateName, context);
-  }
-
-  //resolves a location for this page class's template (assuming @Show is not present)
-  private String resolve(Class<?> pageClass) {
-    for (String nameTemplate : templateSystem.getTemplateExtensions()) {
-      String name = String.format(nameTemplate, pageClass.getSimpleName());
-      URL resource = pageClass.getResource(name);
-
-      if (null != resource) {
-        return name;
-      }
-    }
-
-    return null;
   }
 
   private static String read(InputStream stream) throws IOException {
@@ -201,17 +209,17 @@ public class TemplateLoader {
     return builder.toString();
   }
 
-  public Renderable compile(Class<?> templateClass) {   
+  public Renderable compile(Class<?> templateClass) {
     Template template = load(templateClass);
     TemplateCompiler templateCompiler = templateSystem.compilerFor(template.getName());
     //
     // This is how the old mechanism worked, for example if dynamic.js comes through the system we still pass back
     // the html compiler. JVZ: not sure why this wouldn't be directly routed to the right resource. TODO: investigate
     //
-    if(templateCompiler == null) {
+    if (templateCompiler == null) {
       templateCompiler = templateSystem.compilerFor("html");
     }
-        
+
     return templateCompiler.compile(templateClass, template);
-  }  
+  }
 }

--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlTemplateCompiler.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlTemplateCompiler.java
@@ -1,30 +1,5 @@
 package com.google.sitebricks.compiler;
 
-import static com.google.sitebricks.compiler.AnnotationNode.ANNOTATION;
-import static com.google.sitebricks.compiler.AnnotationNode.ANNOTATION_CONTENT;
-import static com.google.sitebricks.compiler.AnnotationNode.ANNOTATION_KEY;
-import static com.google.sitebricks.compiler.HtmlParser.LINE_NUMBER_ATTRIBUTE;
-import static com.google.sitebricks.compiler.HtmlParser.SKIP_ATTR;
-
-import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-
-import org.jetbrains.annotations.NotNull;
-import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.Attributes;
-import org.jsoup.nodes.Comment;
-import org.jsoup.nodes.DataNode;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-import org.jsoup.nodes.TextNode;
-import org.jsoup.nodes.XmlDeclaration;
-import org.softee.util.Preconditions;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -38,6 +13,16 @@ import com.google.sitebricks.rendering.control.WidgetChain;
 import com.google.sitebricks.rendering.control.WidgetRegistry;
 import com.google.sitebricks.routing.PageBook;
 import com.google.sitebricks.routing.SystemMetrics;
+import org.jetbrains.annotations.NotNull;
+import org.jsoup.nodes.*;
+import org.softee.util.Preconditions;
+
+import java.lang.reflect.Type;
+import java.util.*;
+
+import static com.google.sitebricks.compiler.AnnotationNode.*;
+import static com.google.sitebricks.compiler.HtmlParser.LINE_NUMBER_ATTRIBUTE;
+import static com.google.sitebricks.compiler.HtmlParser.SKIP_ATTR;
 
 /**
  * @author Shawn based on XMLTemplateCompiler by Dhanji R. Prasanna (dhanji@gmail.com)

--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/XmlTemplateCompiler.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/XmlTemplateCompiler.java
@@ -1,25 +1,5 @@
 package com.google.sitebricks.compiler;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-
-import org.dom4j.Attribute;
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentType;
-import org.dom4j.Element;
-import org.dom4j.Node;
-import org.dom4j.io.SAXReader;
-import org.jetbrains.annotations.NotNull;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -32,6 +12,20 @@ import com.google.sitebricks.rendering.control.WidgetChain;
 import com.google.sitebricks.rendering.control.WidgetRegistry;
 import com.google.sitebricks.routing.PageBook;
 import com.google.sitebricks.routing.SystemMetrics;
+import org.dom4j.*;
+import org.dom4j.io.SAXReader;
+import org.jetbrains.annotations.NotNull;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)

--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/template/freemarker/FreemarkerTemplateCompiler.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/template/freemarker/FreemarkerTemplateCompiler.java
@@ -1,10 +1,5 @@
 package com.google.sitebricks.compiler.template.freemarker;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-
 import com.google.inject.Singleton;
 import com.google.sitebricks.compiler.TemplateCompiler;
 import com.google.sitebricks.compiler.template.AbstractMagicTemplateCompiler;
@@ -14,6 +9,11 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 
 @Singleton
 public class FreemarkerTemplateCompiler extends AbstractMagicTemplateCompiler implements TemplateCompiler {
@@ -51,6 +51,7 @@ public class FreemarkerTemplateCompiler extends AbstractMagicTemplateCompiler im
   }
 
   class SitebricksTemplateExceptionHandler implements TemplateExceptionHandler {
+
     public void handleTemplateException(TemplateException te, Environment env, Writer out) throws TemplateException {
       // We intentionally do nothing here
     }

--- a/sitebricks/src/test/java/com/google/sitebricks/TemplateLoaderTest.java
+++ b/sitebricks/src/test/java/com/google/sitebricks/TemplateLoaderTest.java
@@ -1,17 +1,19 @@
 package com.google.sitebricks;
 
-import java.util.HashMap;
-
 import com.google.inject.Provider;
 import com.google.sitebricks.compiler.TemplateCompiler;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
+
 import javax.servlet.ServletContext;
 
-
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
@@ -30,12 +32,17 @@ public class TemplateLoaderTest {
     }
 
     TemplateSystem templateSystem() {
-      return new DefaultTemplateSystem(new HashMap<String,TemplateCompiler>());
+      return new DefaultTemplateSystem(new HashMap<String,TemplateCompiler>()) {
+        @Override
+        public String[] getTemplateExtensions() {
+            return new String[]{ "%s.html", "%s.xhtml", "%s.xml", "%s.txt", "%s.fml", "%s.dml", "%s.mvel" };
+        }
+      };
     }
-    
+
     @Test(dataProvider = CLASSES_AND_TEMPLATES)
     public final void loadExplicitXmlTemplate(final Class<MyXmlPage> pageClass) {
-        String template = new TemplateLoader(null, null, null, null, templateSystem()).load(pageClass).getText();
+        String template = new TemplateLoader(new MockServletContextProvider(createMock(ServletContext.class)), templateSystem()).load(pageClass).getText();
         assert null != template : "no template found!";
         template = template.trim();
         assert template.startsWith("<xml>") && template.endsWith("</xml>"); //a weak sauce test
@@ -44,27 +51,51 @@ public class TemplateLoaderTest {
 
     @Test
     public void testItShouldLoadShowValueFromWebInf() {
-        ServletContext ctx = createMock(ServletContext.class);
+      ServletContext ctx = createMock(ServletContext.class);
 
-        // we are telling that WEB-INF folder contains MetaInfPage.html
-        String realPath = TemplateLoaderTest.class.getResource("My.xml").getPath();
+      // we are telling that WEB-INF folder contains MetaInfPage.html
+      String realPath = TemplateLoaderTest.class.getResource("My.xml").getPath();
 
+      expect(ctx.getRealPath("MetaInfPage.html")).andReturn("unknown");
+      expect(ctx.getRealPath("/WEB-INF/MetaInfPage.html")).andReturn(realPath);
 
-        expect(ctx.getRealPath("MetaInfPage.html")).andReturn("unknown"); 
-        expect(ctx.getRealPath("MyMetaInfPage.html")).andReturn("unknown");
-        expect(ctx.getRealPath("/WEB-INF/MyMetaInfPage.html")).andReturn("unknown");
-        expect(ctx.getRealPath("/WEB-INF/MetaInfPage.html")).andReturn(realPath);
+      replay(ctx);
+      String template = new TemplateLoader(new MockServletContextProvider(ctx), templateSystem()).load(MyMetaInfPage.class).getText();
+      verify(ctx);
 
-        replay(ctx);
-        String template = new TemplateLoader(null, null, null, new MockServletContextProvider(ctx), templateSystem()).load(MyMetaInfPage.class).getText();
-        verify(ctx);
-        
-        assert  null != template : "no template found!";
-        assert  template.contains("hello") : "template was not loaded correctly?";
+      assert  null != template : "no template found!";
+      assert  template.contains("hello") : "template was not loaded correctly?";
+    }
+
+    @Test
+    public void testItShouldLoadDefaultValueFromWebInf() {
+      ServletContext ctx = createMock(ServletContext.class);
+
+      // we are telling that WEB-INF folder contains MetaInfPage.html
+      String realPath = TemplateLoaderTest.class.getResource("My.xml").getPath();
+
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.html")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.xhtml")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.xml")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.txt")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.fml")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.dml")).andReturn("unknown");
+      expect(ctx.getRealPath("MyDefaultMetaInfPage.mvel")).andReturn("unknown");
+      expect(ctx.getRealPath("/WEB-INF/MyDefaultMetaInfPage.html")).andReturn(realPath);
+
+      replay(ctx);
+      String template = new TemplateLoader(new MockServletContextProvider(ctx), templateSystem()).load(MyDefaultMetaInfPage.class).getText();
+      verify(ctx);
+
+      assert  null != template : "no template found!";
+      assert  template.contains("hello") : "template was not loaded correctly?";
     }
 
     @Show("MetaInfPage.html")
     public static class MyMetaInfPage { }
+
+    @Show()
+    public static class MyDefaultMetaInfPage { }
 
     @Show("My.xml")
     public static class MyXmlPage { }

--- a/slf4j/pom.atom
+++ b/slf4j/pom.atom
@@ -1,6 +1,6 @@
 project "Sitebricks :: SLF4J Module" @ "null"
-  id: com.google.sitebricks:sitebricks-slf4j:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-slf4j:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.testng:testng:${org.testng.version}(jdk15)

--- a/stat/pom.atom
+++ b/stat/pom.atom
@@ -1,8 +1,8 @@
 repositories << "http://google-gson.googlecode.com/svn/mavenrepo"
 
 project "Sitebricks :: Statistics" @ "null"
-  id: com.google.sitebricks:sitebricks-stat:0.8.6-SNAPSHOT
-  inherit: com.google.sitebricks:sitebricks-parent:0.8.6-SNAPSHOT:../pom.atom
+  id: com.google.sitebricks:sitebricks-stat:0.8.7-SNAPSHOT
+  inherit: com.google.sitebricks:sitebricks-parent:0.8.7-SNAPSHOT:../pom.atom
   packaging: jar
 
   deps: [ org.testng:testng:${org.testng.version}(jdk15)


### PR DESCRIPTION
I pulled in the latest from trunk so I could make use of the new configurable template compiler support, but there was a little more work that had to be done.

It was about 90% of the way there, but a few places had file extensions hard coded, and there was no easy way to add custom compilers from outside the Sitebricks codebase.

You can now add custom template compilers by overriding the `SiteBricks.configureTemplateCompilers` method:

```
public class MySitebricksModule extends SitebricksModule {
...
    @Override
    protected void configureTemplateCompilers(MapBinder<String, TemplateCompiler> compilers) {
        compilers.addBinding("mustache").to(MustacheTemplateCompiler.class);
        compilers.addBinding("mu").to(MustacheTemplateCompiler.class);
    }
}
```

Or, you can bind them anywhere in your modules by adding to the existing Guice MapBinder:

```
MapBinder<String,TemplateCompiler> templateCompilers = MapBinder.newMapBinder(binder(), String.class, TemplateCompiler.class);
templateCompilers.addBinding("mustache").to(MustacheTemplateCompiler.class);
templateCompilers.addBinding("mu").to(MustacheTemplateCompiler.class);
```

I also cleaned up the `TemplateLoader` class to be easier to follow. The original logic was a bit convoluted, and it wasn't very intuitive to know what was happening for the different cases (@Show() vs @Show(template) vs @Show(template.html), etc). I reworked it so that it short-circuits the deep search if a file extension is specified in the Show annotation (e.g. `@Show(template.html)`), and it looks for all possibilities in one resource path before moving on to the next.

I also updated the pom.atom files to use the lates 8.7-SNAPSHOT, which just looked like some housekeeping that got missed.

Let me know if there's anything in here you'd like me to update.
