### PR TITLE
Fix test-support Jetty port binding to use available port

### DIFF
--- a/sitebricks-test-support/src/main/java/com/google/sitebricks/acceptance/util/Jetty.java
+++ b/sitebricks-test-support/src/main/java/com/google/sitebricks/acceptance/util/Jetty.java
@@ -1,5 +1,6 @@
 package com.google.sitebricks.acceptance.util;
 
+import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.webapp.WebAppContext;
 
@@ -13,8 +14,8 @@ public class Jetty {
 
   public Jetty(String path, int port) {
     this(new WebAppContext(path, APP_NAME), port);
-  }  
-  
+  }
+
   public Jetty(WebAppContext webAppContext, int port) {
     server = new Server(port);
     server.addHandler(webAppContext);
@@ -30,5 +31,12 @@ public class Jetty {
 
   public void stop() throws Exception {
     server.stop();
+  }
+
+  public int getListeningPort() {
+    for (Connector connector : server.getConnectors()) {
+      return connector.getLocalPort();
+    }
+    throw new IllegalStateException("No port bound");
   }
 }

--- a/sitebricks-test-support/src/main/java/com/google/sitebricks/acceptance/util/SitebricksServiceTest.java
+++ b/sitebricks-test-support/src/main/java/com/google/sitebricks/acceptance/util/SitebricksServiceTest.java
@@ -24,39 +24,33 @@ import com.google.sitebricks.SitebricksModule;
  * Abstract TestNG/JUnit4 test that automatically binds and injects itself.
  */
 public abstract class SitebricksServiceTest implements Module {
-  
+
   // ----------------------------------------------------------------------
   // Implementation fields
   // ----------------------------------------------------------------------
 
   private String basedir;
-  private Injector injector;  
+  private Injector injector;
   private Jetty server;
-  private int port;
-  
+
   // ----------------------------------------------------------------------
   // Setup
   // ----------------------------------------------------------------------
-  
+
   @BeforeSuite
   public void beforeSuite() throws Exception {
     //
     // Find a free port for the tests
     //
-    port = testPort(); 
-    server = new Jetty("src/test/webapp", port);    
+    server = new Jetty("src/test/webapp", 0);
     server.start();
   }
-  
-  protected int testPort() throws Exception {
-    return new ServerSocket(0).getLocalPort();        
-  }
-  
-  @AfterSuite 
+
+  @AfterSuite
   public void afterSuite() throws Exception {
     server.stop();
   }
-  
+
   @Before
   @BeforeMethod
   public void setUp() {
@@ -66,7 +60,7 @@ public abstract class SitebricksServiceTest implements Module {
   protected SitebricksModule sitebricksModule() {
     return new SitebricksModule();
   }
-  
+
   @After
   @AfterMethod
   public void tearDown() {
@@ -85,7 +79,7 @@ public abstract class SitebricksServiceTest implements Module {
 
   /**
    * Custom injection bindings.
-   * 
+   *
    * @param binder
    *          The Guice binder
    */
@@ -95,7 +89,7 @@ public abstract class SitebricksServiceTest implements Module {
 
   /**
    * Custom property values.
-   * 
+   *
    * @param properties
    *          The test properties
    */
@@ -141,8 +135,8 @@ public abstract class SitebricksServiceTest implements Module {
   private final <T> T lookup(final Key<T> key) {
     return injector.getInstance(key);
   }
-  
+
   protected String baseUrl() {
-    return "http://localhost:" + port + "/sitebricks";
+    return "http://localhost:" + server.getListeningPort() + "/sitebricks";
   }
 }


### PR DESCRIPTION
I pulled the latest from master (1f2ab203019866aa8a52d99bb754d10aeb06a179) and tried building on Windows 7, but encountered an error in Easy Client. The use of new ServerSocket(0).getLocalPort() binds the socket to an available port, which is then not available for use by Jetty, causing the failed SocketConnector@0.0.0.0:54560 java.net.BindException: Address already in use: JVM_Bind exception below.

This pull request allows Jetty to find an available port to bind for tests rather than attempting to find an available port ourselves and avoiding "java.net.BindException: Address already in use". After making these changes, sitebricks successfully passes all tests and installs cleanly.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.sitebricks.client.easy.SisuSitebricksClientModuleTest
10:24:15.852 [main] INFO  org.mortbay.log - Logging to Logger[org.mortbay.log] via org.mortbay.log.Slf4jLog
10:24:15.856 [main] DEBUG org.mortbay.log - Container Server@643ae941 + SocketConnector@0.0.0.0:54560 as connector
10:24:15.856 [main] DEBUG org.mortbay.log - Container Server@643ae941 + org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp} as handler
10:24:15.856 [main] DEBUG org.mortbay.log - Container SecurityHandler@4dd36dfe + ServletHandler@73da669c as handler
10:24:15.856 [main] DEBUG org.mortbay.log - Container SessionHandler@786c730 + SecurityHandler@4dd36dfe as handler
10:24:15.856 [main] DEBUG org.mortbay.log - Container SessionHandler@786c730 + org.mortbay.jetty.servlet.HashSessionManager@217f242c as sessionManager
10:24:15.856 [main] DEBUG org.mortbay.log - Container org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp} + SessionHandler@786c730 as handler
10:24:15.856 [main] DEBUG org.mortbay.log - Container org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp} + ErrorPageErrorHandler@221fd5e2 as error
10:24:15.857 [main] INFO  org.mortbay.log - jetty-6.1.9
10:24:15.868 [main] DEBUG org.mortbay.log - Container Server@643ae941 + org.mortbay.thread.BoundedThreadPool@6426d607 as threadpool
10:24:15.869 [main] DEBUG org.mortbay.log - started org.mortbay.thread.BoundedThreadPool@6426d607
10:24:15.895 [main] DEBUG org.mortbay.log - Thread Context class loader is: ContextLoader@null([]) / sun.misc.Launcher$AppClassLoader@b92d342
10:24:15.895 [main] DEBUG org.mortbay.log - Parent class loader is: sun.misc.Launcher$AppClassLoader@b92d342
10:24:15.895 [main] DEBUG org.mortbay.log - Parent class loader is: sun.misc.Launcher$ExtClassLoader@546b97fd
10:24:15.900 [main] DEBUG org.mortbay.log - Checking Resource aliases
10:24:15.901 [main] DEBUG org.mortbay.log - Try webapp=file:/D:/dev/oss/sitebricks/sitebricks-easy-client/src/test/webapp/, exists=true, directory=true
10:24:15.901 [main] DEBUG org.mortbay.log - webapp=file:/D:/dev/oss/sitebricks/sitebricks-easy-client/src/test/webapp/
10:24:15.904 [main] DEBUG org.mortbay.log - Created temp dir C:\Temp\Jetty_0_0_0_0_54560_webapp__sitebricks__89clcd for org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp}
10:24:15.920 [main] DEBUG org.mortbay.log - getResource(org/mortbay/jetty/webapp/webdefault.xml)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/jetty/6.1.9/jetty-6.1.9.jar!/org/mortbay/jetty/webapp/webdefault.xml
10:24:15.922 [main] DEBUG org.mortbay.log - parse: jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/jetty/6.1.9/jetty-6.1.9.jar!/org/mortbay/jetty/webapp/webdefault.xml
10:24:15.924 [main] DEBUG org.mortbay.log - parsing: sid=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/jetty/6.1.9/jetty-6.1.9.jar!/org/mortbay/jetty/webapp/webdefault.xml,pid=null
10:24:15.941 [main] DEBUG org.mortbay.log - ContextParam: org.mortbay.jetty.webapp.NoTLDJarPattern=start.jar|ant-.*\.jar|dojo-.*\.jar|jetty-.*\.jar|jsp-api-.*\.jar|junit-.*\.jar|servlet-api-.*\.jar|dnsns\.jar|rt\.jar|jsse\.jar|tools\.jar|sunpkcs11\.jar|sunjce_provider\.jar|xerces.*\.jar
10:24:15.946 [main] INFO  org.mortbay.log - NO JSP Support for /sitebricks, did not find org.apache.jasper.servlet.JspServlet
10:24:15.951 [main] DEBUG org.mortbay.log - filterNameMap=null
10:24:15.951 [main] DEBUG org.mortbay.log - pathFilters=[]
10:24:15.951 [main] DEBUG org.mortbay.log - servletFilterMap=null
10:24:15.952 [main] DEBUG org.mortbay.log - servletPathMap=null
10:24:15.952 [main] DEBUG org.mortbay.log - servletNameMap=null
10:24:15.952 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + default as servlet
10:24:15.952 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + jsp as servlet
10:24:15.952 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + (S=default,[/]) as servletMapping
10:24:15.952 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + (S=jsp,[*.jsp, *.jspf, *.jspx, *.xsp, *.JSP, *.JSPF, *.JSPX, *.XSP]) as servletMapping
10:24:15.954 [main] DEBUG org.mortbay.log - filterNameMap=null
10:24:15.954 [main] DEBUG org.mortbay.log - pathFilters=[]
10:24:15.954 [main] DEBUG org.mortbay.log - servletFilterMap=null
10:24:15.954 [main] DEBUG org.mortbay.log - servletPathMap={*.XSP=jsp, *.JSPX=jsp, *.jspf=jsp, *.jsp=jsp, *.JSPF=jsp, *.jspx=jsp, *.xsp=jsp, /=default, *.JSP=jsp}
10:24:15.954 [main] DEBUG org.mortbay.log - servletNameMap={jsp=jsp, default=default}
10:24:15.955 [main] DEBUG org.mortbay.log - parse: file:/D:/dev/oss/sitebricks/sitebricks-easy-client/src/test/webapp/WEB-INF/web.xml
10:24:15.955 [main] DEBUG org.mortbay.log - parsing: sid=file:/D:/dev/oss/sitebricks/sitebricks-easy-client/src/test/webapp/WEB-INF/web.xml,pid=null
10:24:15.957 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + guiceFilter as filter
10:24:15.957 [main] DEBUG org.mortbay.log - Container ServletHandler@73da669c + (F=guiceFilter,[/*],[],0) as filterMapping
10:24:15.957 [main] DEBUG org.mortbay.log - filterNameMap={guiceFilter=guiceFilter}
10:24:15.957 [main] DEBUG org.mortbay.log - pathFilters=[(F=guiceFilter,[/*],[],0)]
10:24:15.957 [main] DEBUG org.mortbay.log - servletFilterMap=null
10:24:15.957 [main] DEBUG org.mortbay.log - servletPathMap={*.XSP=jsp, *.JSPX=jsp, *.jspf=jsp, *.jsp=jsp, *.JSPF=jsp, *.jspx=jsp, *.xsp=jsp, /=default, *.JSP=jsp}
10:24:15.958 [main] DEBUG org.mortbay.log - servletNameMap={jsp=jsp, default=default}
10:24:15.958 [main] DEBUG org.mortbay.log - filterNameMap={guiceFilter=guiceFilter}
10:24:15.958 [main] DEBUG org.mortbay.log - pathFilters=[(F=guiceFilter,[/*],[],0)]
10:24:15.958 [main] DEBUG org.mortbay.log - servletFilterMap=null
10:24:15.958 [main] DEBUG org.mortbay.log - servletPathMap={*.XSP=jsp, *.JSPX=jsp, *.jspf=jsp, *.jsp=jsp, *.JSPF=jsp, *.jspx=jsp, *.xsp=jsp, /=default, *.JSP=jsp}
10:24:15.959 [main] DEBUG org.mortbay.log - servletNameMap={jsp=jsp, default=default}
10:24:15.959 [main] DEBUG org.mortbay.log - Configuring web-jetty.xml
10:24:15.960 [main] DEBUG org.mortbay.log - TLD search of file:/D:/dev/oss/sitebricks/sitebricks-easy-client/target/surefire/surefirebooter6532934242447121600.jar
10:24:15.961 [main] DEBUG org.mortbay.log - TLD search of file:/D:/opt/jdk1.6.0_32/jre/lib/ext/localedata.jar
10:24:15.962 [main] DEBUG org.mortbay.log - loaded class com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl from null
10:24:15.963 [main] DEBUG org.mortbay.log - loaded class com.sun.org.apache.xerces.internal.impl.dv.dtd.DTDDVFactoryImpl from null
10:24:15.963 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
10:24:15.964 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
10:24:15.964 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
10:24:15.965 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
10:24:15.965 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
10:24:15.966 [main] DEBUG org.mortbay.log - getResource(javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd)=jar:file:/C:/Users/dschlosn/.m2/repository/org/mortbay/jetty/servlet-api-2.5/6.1.9/servlet-api-2.5-6.1.9.jar!/javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
10:24:15.967 [main] DEBUG org.mortbay.log - Container Server@643ae941 + org.mortbay.jetty.servlet.HashSessionIdManager@2c31f2a7 as sessionIdManager
10:24:15.968 [main] DEBUG org.mortbay.log - started org.mortbay.jetty.servlet.HashSessionIdManager@2c31f2a7
10:24:15.969 [main] DEBUG org.mortbay.log - started org.mortbay.jetty.servlet.HashSessionManager@217f242c
10:24:15.969 [main] DEBUG org.mortbay.log - filterNameMap={guiceFilter=guiceFilter}
10:24:15.969 [main] DEBUG org.mortbay.log - pathFilters=[(F=guiceFilter,[/*],[],0)]
10:24:15.970 [main] DEBUG org.mortbay.log - servletFilterMap=null
10:24:15.970 [main] DEBUG org.mortbay.log - servletPathMap={*.XSP=jsp, *.JSPX=jsp, *.jspf=jsp, *.jsp=jsp, *.JSPF=jsp, *.jspx=jsp, *.xsp=jsp, /=default, *.JSP=jsp}
10:24:15.970 [main] DEBUG org.mortbay.log - servletNameMap={jsp=jsp, default=default}
10:24:15.970 [main] DEBUG org.mortbay.log - starting ServletHandler@73da669c
10:24:15.970 [main] DEBUG org.mortbay.log - started ServletHandler@73da669c
10:24:15.970 [main] DEBUG org.mortbay.log - starting SecurityHandler@4dd36dfe
10:24:15.970 [main] DEBUG org.mortbay.log - started SecurityHandler@4dd36dfe
10:24:15.970 [main] DEBUG org.mortbay.log - starting SessionHandler@786c730
10:24:15.970 [main] DEBUG org.mortbay.log - started SessionHandler@786c730
10:24:15.970 [main] DEBUG org.mortbay.log - starting org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp}
10:24:15.970 [main] DEBUG org.mortbay.log - starting ErrorPageErrorHandler@221fd5e2
10:24:15.970 [main] DEBUG org.mortbay.log - started ErrorPageErrorHandler@221fd5e2
10:24:15.973 [main] DEBUG org.mortbay.log - loaded class com.google.inject.servlet.GuiceFilter from sun.misc.Launcher$AppClassLoader@b92d342
10:24:15.973 [main] DEBUG org.mortbay.log - Holding class com.google.inject.servlet.GuiceFilter
10:24:15.976 [main] DEBUG org.mortbay.log - started guiceFilter
10:24:15.978 [main] DEBUG org.mortbay.log - loaded class org.mortbay.jetty.servlet.DefaultServlet
10:24:15.978 [main] DEBUG org.mortbay.log - loaded class org.mortbay.jetty.servlet.DefaultServlet from sun.misc.Launcher$AppClassLoader@b92d342
10:24:15.979 [main] DEBUG org.mortbay.log - Holding class org.mortbay.jetty.servlet.DefaultServlet
10:24:15.990 [main] DEBUG org.mortbay.log - started org.mortbay.jetty.servlet.DefaultServlet$NIOResourceCache@5097d026
10:24:15.990 [main] DEBUG org.mortbay.log - started org.mortbay.jetty.ResourceCache@1ee29820
10:24:15.990 [main] DEBUG org.mortbay.log - resource base = file:/D:/dev/oss/sitebricks/sitebricks-easy-client/src/test/webapp/
10:24:15.990 [main] DEBUG org.mortbay.log - started default
10:24:15.991 [main] DEBUG org.mortbay.log - loaded class org.mortbay.servlet.NoJspServlet
10:24:15.991 [main] DEBUG org.mortbay.log - loaded class org.mortbay.servlet.NoJspServlet from sun.misc.Launcher$AppClassLoader@b92d342
10:24:15.991 [main] DEBUG org.mortbay.log - Holding class org.mortbay.servlet.NoJspServlet
10:24:15.991 [main] DEBUG org.mortbay.log - started jsp
10:24:15.991 [main] DEBUG org.mortbay.log - started org.mortbay.jetty.webapp.WebAppContext@57a7ddcf{/sitebricks,src/test/webapp}
10:24:15.991 [main] DEBUG org.mortbay.log - starting Server@643ae941
10:24:15.993 [main] WARN  org.mortbay.log - failed SocketConnector@0.0.0.0:54560
java.net.BindException: Address already in use: JVM_Bind
        at java.net.PlainSocketImpl.socketBind(Native Method)
        at java.net.PlainSocketImpl.bind(PlainSocketImpl.java:383)
        at java.net.ServerSocket.bind(ServerSocket.java:328)
        at java.net.ServerSocket.<init>(ServerSocket.java:194)
        at java.net.ServerSocket.<init>(ServerSocket.java:150)
        at org.mortbay.jetty.bio.SocketConnector.newServerSocket(SocketConnector.java:80)
        at org.mortbay.jetty.bio.SocketConnector.open(SocketConnector.java:73)
        at org.mortbay.jetty.AbstractConnector.doStart(AbstractConnector.java:272)
        at org.mortbay.jetty.bio.SocketConnector.doStart(SocketConnector.java:147)
        at org.mortbay.component.AbstractLifeCycle.start(AbstractLifeCycle.java:39)
        at org.mortbay.jetty.Server.doStart(Server.java:233)
        at org.mortbay.component.AbstractLifeCycle.start(AbstractLifeCycle.java:39)
        at com.google.sitebricks.acceptance.util.Jetty.start(Jetty.java:24)
        at com.google.sitebricks.acceptance.util.SitebricksServiceTest.beforeSuite(SitebricksServiceTest.java:48)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:80)
        at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:543)
        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:212)
        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:138)
        at org.testng.SuiteRunner.privateRun(SuiteRunner.java:278)
        at org.testng.SuiteRunner.run(SuiteRunner.java:241)
        at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
        at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
        at org.testng.TestNG.runSuitesSequentially(TestNG.java:1169)
        at org.testng.TestNG.runSuitesLocally(TestNG.java:1094)
        at org.testng.TestNG.run(TestNG.java:1006)
        at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:70)
        at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:109)
        at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:111)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
        at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
        at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcessWhenForked(SurefireStarter.java:107)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
10:24:15.993 [main] WARN  org.mortbay.log - failed Server@643ae941
java.net.BindException: Address already in use: JVM_Bind
        at java.net.PlainSocketImpl.socketBind(Native Method)
        at java.net.PlainSocketImpl.bind(PlainSocketImpl.java:383)
        at java.net.ServerSocket.bind(ServerSocket.java:328)
        at java.net.ServerSocket.<init>(ServerSocket.java:194)
        at java.net.ServerSocket.<init>(ServerSocket.java:150)
        at org.mortbay.jetty.bio.SocketConnector.newServerSocket(SocketConnector.java:80)
        at org.mortbay.jetty.bio.SocketConnector.open(SocketConnector.java:73)
        at org.mortbay.jetty.AbstractConnector.doStart(AbstractConnector.java:272)
        at org.mortbay.jetty.bio.SocketConnector.doStart(SocketConnector.java:147)
        at org.mortbay.component.AbstractLifeCycle.start(AbstractLifeCycle.java:39)
        at org.mortbay.jetty.Server.doStart(Server.java:233)
        at org.mortbay.component.AbstractLifeCycle.start(AbstractLifeCycle.java:39)
        at com.google.sitebricks.acceptance.util.Jetty.start(Jetty.java:24)
        at com.google.sitebricks.acceptance.util.SitebricksServiceTest.beforeSuite(SitebricksServiceTest.java:48)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:80)
        at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:543)
        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:212)
        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:138)
        at org.testng.SuiteRunner.privateRun(SuiteRunner.java:278)
        at org.testng.SuiteRunner.run(SuiteRunner.java:241)
        at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
        at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
        at org.testng.TestNG.runSuitesSequentially(TestNG.java:1169)
        at org.testng.TestNG.runSuitesLocally(TestNG.java:1094)
        at org.testng.TestNG.run(TestNG.java:1006)
        at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:70)
        at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:109)
        at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:111)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
        at java.lang.reflect.Method.invoke(Method.java:597)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
        at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
        at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcessWhenForked(SurefireStarter.java:107)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
Tests run: 44, Failures: 2, Errors: 0, Skipped: 42, Time elapsed: 0.718 sec <<< FAILURE!

Results :

Failed tests:   beforeSuite(org.sitebricks.client.easy.SisuSitebricksClientModuleTest): Address already in use: JVM_Bind
  beforeSuite(org.sitebricks.client.easy.SisuSitebricksClientModuleTest): Address already in use: JVM_Bind

Tests run: 44, Failures: 2, Errors: 0, Skipped: 42

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Sitebricks :: Parent .............................. SUCCESS [0.459s]
[INFO] Sitebricks :: Type Conversion ..................... SUCCESS [2.571s]
[INFO] Sitebricks :: Client .............................. SUCCESS [1.742s]
[INFO] Sitebricks :: Annotations ......................... SUCCESS [0.488s]
[INFO] Sitebricks :: Core ................................ SUCCESS [6.733s]
[INFO] Sitebricks :: Test Support ........................ SUCCESS [0.798s]
[INFO] Sitebricks :: Easy Client ......................... FAILURE [2.358s]
[INFO] Sitebricks :: Statistics .......................... SKIPPED
[INFO] Sitebricks :: Acceptance Tests .................... SKIPPED
[INFO] Sitebricks :: Mail Client ......................... SKIPPED
[INFO] Sitebricks :: Options Module ...................... SKIPPED
[INFO] Sitebricks :: Jetty Archetype ..................... SKIPPED
[INFO] Sitebricks :: SLF4J Module ........................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 15.452s
[INFO] Finished at: Fri Jun 22 10:24:16 EDT 2012
[INFO] Final Memory: 45M/188M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.10:test (default-test) on project sitebricks-easy-client: There are test failures.
[ERROR]
[ERROR] Please refer to D:\dev\oss\sitebricks\sitebricks-easy-client\target\surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :sitebricks-easy-client
```
