### PR TITLE
Small fix in error handling in PageBasedRedirect.

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/routing/PageBasedRedirect.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/routing/PageBasedRedirect.java
@@ -44,7 +44,7 @@ class PageBasedRedirect implements Redirect {
         if (value == null)
           throw new IllegalArgumentException("Missing parameter " + piece
               + " in URI template for page class: " + pageClass.getName()
-              + " '" + at.value() + "'");
+              + " '" + uriTemplate + "'");
 
         uri.append(URLEncoder.encode(value));
       } else


### PR DESCRIPTION
Small fix in error handling in PageBasedRedirect. It used to throw NPE when a bad parameter was passed for a page registered without @At.
