### PR TITLE
Allow non headless pages to return Reply<?>

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/headless/ReplyMaker.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/headless/ReplyMaker.java
@@ -192,5 +192,43 @@ class ReplyMaker<E> extends Reply<E> {
       }
     }
   }
+  
+  @Override
+  public boolean equals(Object other) {
+	  if(!(other instanceof ReplyMaker<?>))
+		  return false;
+	  
+	  @SuppressWarnings("unchecked")
+	  ReplyMaker<E> o = (ReplyMaker<E>)other;
+	  if(this.status != o.status)
+		  return false;
+	  
+	  if((this.contentType != o.contentType)
+	  && (this.contentType != null && !this.contentType.equals(o.contentType))
+	  && (this.contentType == null && o.contentType != null))
+		  return false;
+	  
+	  if((this.redirectUri != o.redirectUri)
+	  && (this.redirectUri != null && !this.redirectUri.equals(o.redirectUri))
+	  && (this.redirectUri == null && o.redirectUri != null))
+		  return false;
+	  	  
+	  if(!this.headers.equals(o.headers))
+		  return false;
+	  
+	  if(!this.transport.equals(o.transport))
+		  return false;
+	  
+	  if(this.templateKey != o.templateKey)
+		  return false;
+
+	  if((this.entity != o.entity)
+	  && (this.entity != null && !this.entity.equals(o.entity))
+	  && (this.entity == null && o.entity != null))
+		  return false;
+	  
+	  // All tests passed, the objects must be equal
+	  return true;
+  }
 }
 

--- a/sitebricks/src/test/java/com/google/sitebricks/headless/ReplyEqualsTest.java
+++ b/sitebricks/src/test/java/com/google/sitebricks/headless/ReplyEqualsTest.java
@@ -1,0 +1,14 @@
+package com.google.sitebricks.headless;
+
+import static org.junit.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class ReplyEqualsTest {
+
+	@Test
+	public void forbidden() {
+		assertTrue(Reply.saying().forbidden().equals(Reply.saying().forbidden()));
+	}
+	
+}


### PR DESCRIPTION
Non-headless pages currently cannot return Reply<?>. Sitebricks throws NPE (WidgetRoutingDispatcher:115) because it mistakes the Reply object for a Page to be used for Page Chaining.

This simple change fixes that issue. I also added a few tests. This doesn't seem to have broken anything, but I'd still appreciate if you'd give it a good look before merging. I'm too unfamiliar with the internals of SiteBricks to be totally comfortable with this change.
