### PR TITLE
Adds support for reading of generic types (using TypeLiteral<T>)

### DIFF
--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/RestfulWebServiceWithGenerics.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/RestfulWebServiceWithGenerics.java
@@ -1,0 +1,47 @@
+package com.google.sitebricks.example;
+
+import com.google.inject.TypeLiteral;
+import com.google.sitebricks.At;
+import com.google.sitebricks.client.transport.Json;
+import com.google.sitebricks.headless.Reply;
+import com.google.sitebricks.headless.Request;
+import com.google.sitebricks.headless.Service;
+import com.google.sitebricks.http.Post;
+import com.google.sitebricks.http.Put;
+
+import java.util.List;
+
+/**
+ * @author Miroslav Genov (mgenov@gmail.com)
+ */
+@At("/serviceWithGenerics") @Service
+public class RestfulWebServiceWithGenerics {
+
+  @Post
+  public Reply<?> addPerson(Request request) {
+
+    List<Person> personList = request.read(new TypeLiteral<List<Person>>() {}).as(Json.class);
+
+    return Reply.with(personList).as(Json.class);
+  }
+
+  public static class Person {
+    private String name;
+
+    Person() {
+
+    }
+
+    public Person(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
@@ -115,6 +115,7 @@ public class SitebricksConfig extends GuiceServletContextListener {
         at("/superpath2/:dynamic").serve(RestfulWebServiceWithSubpaths2.class);
         at("/json/:type").serve(RestfulWebServiceWithCRUD.class);
         at("/jsonConversion").serve(RestfulWebServiceWithCRUDConversions.class);
+        at("/serviceWithGenerics").serve(RestfulWebServiceWithGenerics.class);
 
         at("/pagechain").show(PageChain.class);
         at("/nextpage").show(NextPage.class);

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/RestfulWebServiceWithGenericsAcceptanceTest.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/RestfulWebServiceWithGenericsAcceptanceTest.java
@@ -1,0 +1,56 @@
+package com.google.sitebricks.acceptance;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import com.google.sitebricks.client.Web;
+import com.google.sitebricks.client.WebResponse;
+import com.google.sitebricks.client.transport.Json;
+import com.google.sitebricks.conversion.Converter;
+import com.google.sitebricks.conversion.ConverterRegistry;
+import com.google.sitebricks.conversion.StandardTypeConverter;
+import com.google.sitebricks.example.RestfulWebServiceWithGenerics.Person;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+/**
+ * @author Miroslav Genov (mgenov@gmail.com)
+ */
+@Test(suiteName = AcceptanceTest.SUITE)
+public class RestfulWebServiceWithGenericsAcceptanceTest {
+
+  public void whatWasPostedIsReturnedAsResponse() {
+    List<Person> personList = Lists.newArrayList(new Person("John Smith"));
+
+    WebResponse response = createInjector()
+            .getInstance(Web.class)
+            .clientOf(AcceptanceTest.baseUrl() + "/serviceWithGenerics")
+            .transports(new TypeLiteral<List<Person>>() { })
+            .over(Json.class)
+            .post(personList);
+
+    assert HttpServletResponse.SC_OK == response.status();
+
+    List<Person> result = response.to(new TypeLiteral<List<Person>>() {}).using(Json.class);
+    assert result.size() == 1;
+    assert "John Smith".equals(result.get(0).getName());
+  }
+
+
+  private Injector createInjector() {
+    return Guice.createInjector(new AbstractModule() {
+      protected void configure() {
+        bind(ConverterRegistry.class).toInstance(new StandardTypeConverter(
+                ImmutableSet.<Converter>of()));
+      }
+    });
+  }
+
+
+}

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/AHCWebClient.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/AHCWebClient.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
 import com.ning.http.client.Realm;
@@ -27,16 +28,16 @@ import java.util.concurrent.Executor;
 class AHCWebClient<T> implements WebClient<T> {
   private final String url;
   private final Map<String, String> headers;
-  private final Class<T> classTypeToTransport;
+  private final TypeLiteral<T> typeToTransform;
   private final AsyncHttpClient httpClient;
   private final Transport transport;
   private final Injector injector;
 
-  public AHCWebClient(Injector injector, Transport transport, Web.Auth authType, String username, String password, String url, Map<String, String> headers, Class<T> classTypeToTransport) {
+  public AHCWebClient(Injector injector, Transport transport, Web.Auth authType, String username, String password, String url, Map<String, String> headers, TypeLiteral<T> typeToTransform) {
     this.injector = injector;
     this.url = url;
     this.headers = (null == headers) ? null : ImmutableMap.copyOf(headers);
-    this.classTypeToTransport = classTypeToTransport;
+    this.typeToTransform = typeToTransform;
     this.transport = transport;
 
     // configure auth
@@ -101,7 +102,7 @@ class AHCWebClient<T> implements WebClient<T> {
       // Read the entity from the transport plugin.
       //
       final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-      transport.out(stream, classTypeToTransport, t);
+      transport.out(stream, typeToTransform.getRawType(), t);
 
       // TODO worry about endian issues? Or will Content-Encoding be sufficient?
       // OOM if the stream is too bug
@@ -139,7 +140,7 @@ class AHCWebClient<T> implements WebClient<T> {
         in = (InputStream) t;
       else {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        transport.out(stream, classTypeToTransport, t);
+        transport.out(stream, typeToTransform.getRawType(), t);
 
         in = new ByteArrayInputStream(stream.toByteArray());
       }

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/Transport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/Transport.java
@@ -1,5 +1,7 @@
 package com.google.sitebricks.client;
 
+import com.google.inject.TypeLiteral;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -24,6 +26,20 @@ public interface Transport {
   <T> T in(InputStream in, Class<T> type) throws IOException;
 
   /**
+   * Reads from a given inputstream and returns an object representing the unmarshalled
+   * form of the underlying protocol data.
+   *
+   * @param in   An inputstream to read data from. This stream will NOT be closed
+   *             by the implementation of this interface.
+   * @param type The TypeLiteral which is representing a generic type to read in. The method will return an instance of the
+   *             generic type representing the data in the {@code in} stream.
+   * @return An instance of {@code type} representing the data in the provided
+   *         stream.
+   * @throws IOException Thrown if there is an error reading from this stream.
+   */
+  <T> T in(InputStream in, TypeLiteral<T> type) throws IOException;
+
+  /**
    * Converts a given object into transportable data and writes it to the provided
    * OutputStream.
    *
@@ -34,6 +50,7 @@ public interface Transport {
    * @throws IOException Thrown if there is an error writing to this stream.
    */
   <T> void out(OutputStream out, Class<T> type, T data) throws IOException;
+
 
   /**
    * Returns the HTTP content type marshalled by this transport. For example, the

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/Web.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/Web.java
@@ -1,6 +1,7 @@
 package com.google.sitebricks.client;
 
 import com.google.inject.ImplementedBy;
+import com.google.inject.TypeLiteral;
 
 import java.util.Map;
 
@@ -19,6 +20,8 @@ public interface Web {
 
   static interface FormatBuilder {
     <T> ReadAsBuilder<T> transports(Class<T> clazz);
+
+    <T> ReadAsBuilder<T> transports(TypeLiteral<T> clazz);
 
     <T> WebClient<T> transportsText();
 

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/WebClientBuilder.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/WebClientBuilder.java
@@ -3,6 +3,8 @@ package com.google.sitebricks.client;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.sitebricks.client.Web.ReadAsBuilder;
 import com.google.sitebricks.client.transport.Text;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -43,6 +45,11 @@ class WebClientBuilder implements Web.FormatBuilder {
   }
 
   public <T> Web.ReadAsBuilder<T> transports(Class<T> clazz) {
+    return new InternalReadAsBuilder<T>(new TypeLiteral<T>() {});
+  }
+
+  @Override
+  public <T> ReadAsBuilder<T> transports(TypeLiteral<T> clazz) {
     return new InternalReadAsBuilder<T>(clazz);
   }
 
@@ -64,9 +71,9 @@ class WebClientBuilder implements Web.FormatBuilder {
   }
 
   private class InternalReadAsBuilder<T> implements Web.ReadAsBuilder<T> {
-    private final Class<T> transporting;
+    private final TypeLiteral<T> transporting;
 
-    private InternalReadAsBuilder(Class<T> transporting) {
+    private InternalReadAsBuilder(TypeLiteral<T> transporting) {
       this.transporting = transporting;
     }
 

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/WebResponse.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/WebResponse.java
@@ -1,5 +1,7 @@
 package com.google.sitebricks.client;
 
+import com.google.inject.TypeLiteral;
+
 import java.util.Map;
 
 /**
@@ -11,6 +13,8 @@ public interface WebResponse {
   int status();
 
   <T> ResponseTransportBuilder<T> to(Class<T> data);
+
+  <T> ResponseTransportBuilder<T> to(TypeLiteral<T> data);
 
   String toString();
 

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/WebResponseImpl.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/WebResponseImpl.java
@@ -1,6 +1,7 @@
 package com.google.sitebricks.client;
 
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
 import com.ning.http.client.Response;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -45,6 +46,12 @@ class WebResponseImpl implements WebResponse {
   }
 
   public <T> ResponseTransportBuilder<T> to(final Class<T> data) {
+    TypeLiteral<T> typeLiteral = TypeLiteral.get(data);
+    return to(typeLiteral);
+  }
+
+  @Override
+  public <T> ResponseTransportBuilder<T> to(final TypeLiteral<T> data) {
     return new ResponseTransportBuilder<T>() {
       public T using(Class<? extends Transport> transportKey) {
         InputStream in = null;

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/ByteArrayTransport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/ByteArrayTransport.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import com.google.common.io.ByteStreams;
+import com.google.inject.TypeLiteral;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
@@ -14,6 +15,12 @@ class ByteArrayTransport extends Raw {
   @SuppressWarnings("unchecked")
   public <T> T in(InputStream in, Class<T> type) throws IOException {
     assert type == byte[].class;
+    return (T) ByteStreams.toByteArray(in);
+  }
+
+  @Override
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    assert type.getType() == byte[].class;
     return (T) ByteStreams.toByteArray(in);
   }
 

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/JacksonJsonTransport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/JacksonJsonTransport.java
@@ -4,10 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import com.google.inject.TypeLiteral;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.codehaus.jackson.map.type.TypeFactory;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
@@ -30,6 +32,11 @@ public class JacksonJsonTransport extends Json {
     return objectMapper.readValue(in, type);
   }
 
+  @Override
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    return objectMapper.readValue(in, TypeFactory.defaultInstance().constructType(type.getType()));
+  }
+
   public <T> void out(OutputStream out, Class<T> type, T data) {
     try {
       objectMapper.writeValue(out, data);
@@ -37,4 +44,6 @@ public class JacksonJsonTransport extends Json {
       throw new RuntimeException(e);
     }
   }
+
+
 }

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/SimpleTextTransport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/SimpleTextTransport.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
+import com.google.inject.TypeLiteral;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
@@ -17,7 +18,13 @@ class SimpleTextTransport extends Text {
       return type.cast(CharStreams.toString(new InputStreamReader(in)));
     }
 
-    public <T> void out(OutputStream out, Class<T> type, T data) {
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    return (T) CharStreams.toString(new InputStreamReader(in));
+  }
+
+  public <T> void out(OutputStream out, Class<T> type, T data) {
       try {
         ByteStreams.copy(new ByteArrayInputStream(data.toString().getBytes()), out);
       } catch (IOException e) {

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/XStreamXmlTransport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/XStreamXmlTransport.java
@@ -1,6 +1,7 @@
 package com.google.sitebricks.client.transport;
 
 import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
 import com.thoughtworks.xstream.XStream;
 
 import java.io.IOException;
@@ -20,6 +21,12 @@ class XStreamXmlTransport extends Xml {
 
   public <T> T in(InputStream in, Class<T> type) throws IOException {
     return type.cast(xStream.fromXML(in));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    return (T)xStream.fromXML(in);
   }
 
   public <T> void out(OutputStream out, Class<T> type, T data) {

--- a/sitebricks/src/main/java/com/google/sitebricks/headless/Request.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/headless/Request.java
@@ -1,6 +1,7 @@
 package com.google.sitebricks.headless;
 
 import com.google.common.collect.Multimap;
+import com.google.inject.TypeLiteral;
 import com.google.sitebricks.client.Transport;
 
 import java.io.IOException;
@@ -25,6 +26,18 @@ public interface Request {
    * @return an instance containing the deserialized raw data.
    */
   <E> RequestRead<E> read(Class<E> type);
+
+  /**
+   * Reads the raw request data into an generic object. Must
+   * be followed by a transport clause for correct unmarshalling. Example:
+   * <pre>
+   *   List&lt;Person&gt; personList = request.read(new TypeLiteral&lt;List&lt;Person&gt;&gt;(){}).as(Json.class);
+   * </pre>
+   *
+   * @param type The target type to unmarshall the raw request data into.
+   * @return an instance containing the deserialized raw data.
+   */
+  <E> RequestRead<E> read(TypeLiteral<E> type);
 
   /**
    * Reads the request data directly into the given output stream. Useful


### PR DESCRIPTION
Adds support for reading of generic type from request and from the response. 

Here are some example usages: 

``` java

List<Person> personList = request.read(new TypeLiteral<List<Person>>() {}).as(Json.class); 

```

Also the same functionality could be applied and on the response of the web client

``` java
WebResponse response = ...
List<Person> personList = response.to(new TypeLiteral<List<Person>>() {}).using(Json.class);
```
