### PR TITLE
FIX: @Repeat widget in the @Decorated page loses its pageVar 

### DIFF
--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/DecoratedRepeat.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/DecoratedRepeat.java
@@ -1,0 +1,30 @@
+package com.google.sitebricks.example;
+
+import com.google.sitebricks.rendering.Decorated;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@Decorated
+public class DecoratedRepeat extends DecoratorPage {
+
+    private static final List<String> ITEMS = Arrays.asList("one", "two", "three");
+
+    private final String messagePrefix = "Hello, ";
+
+    public String getMessagePrefix() {
+        return messagePrefix;
+    }
+
+    public List<String> getItems() {
+        return ITEMS;
+    }
+
+    @Override
+    public String getWorld() {
+        return "This is a decorated page with a repeat block";
+    }
+}

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
@@ -130,6 +130,8 @@ public class SitebricksConfig extends GuiceServletContextListener {
 
         at("/chat").show(Chatter.class);
 
+        at("/decorated-repeat").show(DecoratedRepeat.class);
+
         embed(HelloWorld.class).as("Hello");
       }
 

--- a/sitebricks-acceptance-tests/src/main/resources/DecoratedRepeat.html
+++ b/sitebricks-acceptance-tests/src/main/resources/DecoratedRepeat.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<ul>
+    @Repeat(items=items, var="it")
+    <li class="item">${__page.messagePrefix}${it}</li>
+</ul>
+</body>
+</html>

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/DecoratedRepeatTest.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/DecoratedRepeatTest.java
@@ -1,0 +1,30 @@
+package com.google.sitebricks.acceptance;
+
+import com.google.sitebricks.acceptance.page.DecoratedRepeatPage;
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import com.google.sitebricks.acceptance.util.JettyAcceptanceTest;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@Test(suiteName = AcceptanceTest.SUITE)
+public class DecoratedRepeatTest {
+    public void shouldRenderPageFieldInsideRepeat() {
+        WebDriver driver = AcceptanceTest.createWebDriver();
+        driver.get(AcceptanceTest.baseUrl() + "/decorated-repeat");
+        DecoratedRepeatPage page = DecoratedRepeatPage.open(driver);
+        List<String> items = page.getItems();
+        assert items.size() == 3;
+        assert "Hello, one".equals(items.get(0));
+        assert "Hello, two".equals(items.get(1));
+        assert "Hello, three".equals(items.get(2));
+    }
+}

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/DecoratedRepeatPage.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/DecoratedRepeatPage.java
@@ -1,0 +1,36 @@
+package com.google.sitebricks.acceptance.page;
+
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+public class DecoratedRepeatPage {
+
+    private final List<WebElement> elements;
+
+    public DecoratedRepeatPage(WebDriver driver) {
+        elements = driver.findElements(By.xpath("//li[@class='item']"));
+    }
+
+    public List<String> getItems() {
+        List<String> items = new ArrayList<String>();
+        for (WebElement e : elements) {
+            items.add(e.getText());
+        }
+        return items;
+    }
+
+    public static DecoratedRepeatPage open(WebDriver driver) {
+        driver.get(AcceptanceTest.baseUrl() + "/decorated-repeat");
+        return PageFactory.initElements(driver, DecoratedRepeatPage.class);
+    }
+
+}

--- a/sitebricks/src/main/java/com/google/sitebricks/rendering/control/DecorateWidget.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/rendering/control/DecorateWidget.java
@@ -52,7 +52,7 @@ public class DecorateWidget implements Renderable {
       PageBook.Page page = book.forName(DecorateWidget.embedNameFor(templateClass));
 
       // create a dummy respond to collect the output of the embedded page
-      StringBuilderRespond sbrespond = new StringBuilderRespond(new Object());
+      StringBuilderRespond sbrespond = new StringBuilderRespond(bound);
       EmbeddedRespond embedded = new EmbeddedRespond(null, sbrespond);
       page.widget().render(bound, embedded);
 


### PR DESCRIPTION
Passes the bound object to the EmbeddedRespond so that the "pageVar" variable in the underlying Repeat widget is not lost

Added  an acceptance test that illustrates the scenario I've been dealing with.
