### PR TITLE
Fixing the line number counting in HtmlParser

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlParser.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlParser.java
@@ -360,14 +360,14 @@ public class HtmlParser {
   }
   
   private void parseTextNode() {
-    String text = tq.consumeTo("<");
-    String annotationText = AnnotationParser.readAnnotation(text);
-    text = AnnotationParser.stripAnnotation(text);
+    String rawText = tq.consumeTo("<");
+    String annotationText = AnnotationParser.readAnnotation(rawText);
+    String text = AnnotationParser.stripAnnotation(rawText);
 
     if (text.length() > 0) {
       TextNode textNode = TextNode.createFromEncoded(text, baseUri);
       // if (pendingAnnotation != null) { pendingAnnotation.apply(textNode); }
-      lines(textNode, text);
+      lines(textNode, rawText);
       add(textNode);
     }
 
@@ -555,13 +555,15 @@ public class HtmlParser {
   }
 
 
-  // TODO - LineCountingTokenQueue
-  //  these line numbers are an inaccurate estimate
-
   private void lines(Node node, String data) {
-    linecount += (LINE_SEPARATOR.split(data).length);
+    Matcher newLinematcher = LINE_SEPARATOR.matcher(data);
+    while (newLinematcher.find()) {
+        linecount++;
+    }
     node.attr(LINE_NUMBER_ATTRIBUTE, String.valueOf(linecount));
   }
+
+
 
   private void whitespace() {
     if (tq.peek() == Character.LINE_SEPARATOR)

--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlTemplateCompiler.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/HtmlTemplateCompiler.java
@@ -160,7 +160,7 @@ public class HtmlTemplateCompiler implements TemplateCompiler {
                 } catch (ExpressionCompileException e) {
                     pc.errors.add(
                             CompileError.in(node.outerHtml())
-                            .near(line(node))
+                            .near(line(n))
                             .causedBy(e)
                     );
                 }

--- a/sitebricks/src/main/java/com/google/sitebricks/compiler/TemplateCompileException.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/compiler/TemplateCompileException.java
@@ -81,25 +81,20 @@ public final class TemplateCompileException extends RuntimeException {
             
             // Context (source code) of the error.
             int lineNumber = error.getLine();
-            builder.append(lineNumber - 1);
-            builder.append(": ");
-          if (lineNumber > templateLines.size() - 1) {
-            continue;
-          }
-            builder.append(templateLines.get(lineNumber - 1));
-            builder.append('\n');
-            builder.append(lineNumber);
-            builder.append(": ");
-            builder.append(templateLines.get(lineNumber));
-            builder.append('\n');
 
-            // Actual error line...
-            int contextLineNumber = lineNumber + 1;
-            builder.append(contextLineNumber);
+            if (lineNumber - 1 >= 0) {
+              builder.append(lineNumber);
+              builder.append(": ");
+              builder.append(templateLines.get(lineNumber - 1));
+              builder.append('\n');
+            }
+
+            builder.append(lineNumber + 1);
             builder.append(": ");
-            String fragment = templateLines.get(contextLineNumber);
+            String fragment = templateLines.get(lineNumber);
             builder.append(fragment);
             builder.append('\n');
+            int contextLineNumber = lineNumber;
 
             // Compute offset (line number width + expression offset).
             int columnPad = Integer.toString(contextLineNumber).length() + 4;

--- a/sitebricks/src/test/java/com/google/sitebricks/compiler/HtmlTemplateCompilerTest.java
+++ b/sitebricks/src/test/java/com/google/sitebricks/compiler/HtmlTemplateCompilerTest.java
@@ -40,6 +40,7 @@ import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)
@@ -250,6 +251,36 @@ public class HtmlTemplateCompilerTest {
     assertEquals(value, expected);
   }
 
+
+   @Test
+   public final void readHtmlWidgetWithError() {
+       try{
+        Renderable widget = compiler()
+                .compile(TestBackingType.class, new Template("<html>\n<div class='${clazz}'>hello</div>\n</html>${qwe}"));
+        fail();
+       } catch (Exception ex){
+           assertEquals(ex.getClass(), TemplateCompileException.class);
+           TemplateCompileException te = (TemplateCompileException) ex;
+           assertEquals(te.getErrors().size(), 1);
+           CompileError error = te.getErrors().get(0);
+           assertEquals(error.getLine(), 2);
+       }
+   }
+
+    @Test
+    public final void readHtmlWidgetWithErrorAndWidget() {
+        try{
+            Renderable widget = compiler()
+                    .compile(TestBackingType.class, new Template("<html>\n<div class='${clazz}'>hello</div>\n\n</html>@ShowIf(true)\n${qwe}"));
+            fail();
+        } catch (Exception ex){
+            assertEquals(ex.getClass(), TemplateCompileException.class);
+            TemplateCompileException te = (TemplateCompileException) ex;
+            assertEquals(te.getErrors().size(), 1);
+            CompileError error = te.getErrors().get(0);
+            assertEquals(error.getLine(), 4);
+        }
+    }
 
   @Test
   public final void readHtmlWidget() {


### PR DESCRIPTION
In the current version the message from the TemplateCompilationException was totally useless as the lineNumberCounting has some bugs in the HtmlParse. Fixed with a short commit, and tested with two unit tests.
