### PR TITLE
Upgrade to Jackson 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <guice.version>3.0</guice.version>
-    <org.codehaus.jackson.version>1.9.0</org.codehaus.jackson.version>
+    <com.fasterxml.jackson.version>2.2.2</com.fasterxml.jackson.version>
     <org.mortbay.jetty.version>9.0.0.RC0</org.mortbay.jetty.version>
     <org.seleniumhq.webdriver.version>0.9.7376</org.seleniumhq.webdriver.version>
     <org.testng.version>5.8</org.testng.version>
@@ -202,20 +202,15 @@
       </dependency>
 
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-core-asl</artifactId>
-        <version>${org.codehaus.jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${org.codehaus.jackson.version}</version>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${com.fasterxml.jackson.version}</version>
       </dependency>
 
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.4</version>
       </dependency>
 
       <dependency>

--- a/sitebricks-acceptance-tests/pom.xml
+++ b/sitebricks-acceptance-tests/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>xalan</artifactId>
       <version>2.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+    </dependency>
 
     <!-- Jetty webserver -->
       <dependency>

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/ConnegPage.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/ConnegPage.java
@@ -4,10 +4,9 @@ import com.google.inject.Guice;
 import com.google.sitebricks.acceptance.util.AcceptanceTest;
 import com.google.sitebricks.client.Web;
 import com.google.sitebricks.client.transport.Text;
+import java.util.Map;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
-
-import java.util.Map;
 
 /**
  * Page object that wraps the content negotiation page.

--- a/sitebricks-client/pom.xml
+++ b/sitebricks-client/pom.xml
@@ -46,12 +46,8 @@
       <artifactId>xstream</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/JacksonJsonTransport.java
+++ b/sitebricks-client/src/main/java/com/google/sitebricks/client/transport/JacksonJsonTransport.java
@@ -4,12 +4,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.inject.TypeLiteral;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.codehaus.jackson.map.type.TypeFactory;
 
 /**
  * @author Dhanji R. Prasanna (dhanji@gmail.com)

--- a/sitebricks-converter/pom.xml
+++ b/sitebricks-converter/pom.xml
@@ -33,12 +33,9 @@
       <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.2.2</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>

--- a/sitebricks-easy-client/pom.xml
+++ b/sitebricks-easy-client/pom.xml
@@ -18,8 +18,8 @@
       <artifactId>sitebricks-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/sitebricks-easy-client/src/main/java/org/sitebricks/client/easy/internal/DefaultRestClient.java
+++ b/sitebricks-easy-client/src/main/java/org/sitebricks/client/easy/internal/DefaultRestClient.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.sitebricks.client.easy.internal;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.sitebricks.At;
 import com.google.sitebricks.client.Web;
 import com.google.sitebricks.client.WebClient;
@@ -21,9 +23,6 @@ import com.google.sitebricks.http.Get;
 import com.google.sitebricks.http.Patch;
 import com.google.sitebricks.http.Post;
 import com.google.sitebricks.http.Put;
-
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.type.TypeFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;

--- a/sitebricks-persist-disk/src/main/java/com/google/sitebricks/persist/disk/DiskEntityStore.java
+++ b/sitebricks-persist-disk/src/main/java/com/google/sitebricks/persist/disk/DiskEntityStore.java
@@ -1,5 +1,6 @@
 package com.google.sitebricks.persist.disk;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.IndexWriter;
@@ -8,7 +9,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
-import org.codehaus.jackson.map.ObjectMapper;
 import com.google.sitebricks.persist.EntityMetadata;
 import com.google.sitebricks.persist.EntityQuery;
 import com.google.sitebricks.persist.EntityStore;

--- a/sitebricks/pom.xml
+++ b/sitebricks/pom.xml
@@ -64,12 +64,8 @@
       <artifactId>async-http-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <!-- jsoup HTML library @ http://jsoup.org/ -->


### PR DESCRIPTION
Sitebricks had previously been using Jackson 1.9.x (from the org.codehaus package), but that version has become the legacy version of Jackson. Instead, Sitebricks should be using the newer Jackson 2.x 9 (from the com.fasterxml package). Changes in this pull request include updating the POM files with the newer Jackson version and making changes in the import statements inside the source code.
