### PR TITLE
FIX: pageVar object in a @Repeat of an embedded "brick" is lost

### DIFF
--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/EmbeddedRepeat.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/EmbeddedRepeat.java
@@ -1,0 +1,13 @@
+package com.google.sitebricks.example;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+public class EmbeddedRepeat {
+
+    private final String title = "Page host for an embedded widget";
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
@@ -154,6 +154,9 @@ public class SitebricksConfig extends GuiceServletContextListener {
 
         at("/decorated-repeat").show(DecoratedRepeat.class);
 
+        at("/embedded-repeat").show(EmbeddedRepeat.class);
+        embed(ThreeTestItems.class).as("ThreeTestItems");
+
         at("/jsp").show(Jsp.class);
 
         embed(HelloWorld.class).as("Hello");

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/ThreeTestItems.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/ThreeTestItems.java
@@ -1,0 +1,29 @@
+package com.google.sitebricks.example;
+
+import com.google.sitebricks.rendering.EmbedAs;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@EmbedAs("ThreeTestItems")
+public class ThreeTestItems {
+
+    private static final List<String> ITEMS = Arrays.asList("first", "second", "third");
+
+    private String suffix;
+
+    public List<String> getItems() {
+        return ITEMS;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+}

--- a/sitebricks-acceptance-tests/src/main/resources/EmbeddedRepeat.html
+++ b/sitebricks-acceptance-tests/src/main/resources/EmbeddedRepeat.html
@@ -1,0 +1,11 @@
+<html>
+    <body>
+        <div>
+        <h1>${title}</h1>
+
+        @ThreeTestItems(suffix=" item")
+        <ul />
+        </div>
+
+    </body>
+</html>

--- a/sitebricks-acceptance-tests/src/main/resources/ThreeTestItems.html
+++ b/sitebricks-acceptance-tests/src/main/resources/ThreeTestItems.html
@@ -1,0 +1,4 @@
+<ul>
+    @Repeat(items=items, var="it")
+    <li class="item">${it}${__page.suffix}</li>
+</ul>

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/EmbeddedRepeatTest.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/EmbeddedRepeatTest.java
@@ -1,0 +1,26 @@
+package com.google.sitebricks.acceptance;
+
+import com.google.sitebricks.acceptance.page.EmbeddedRepeatPage;
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@Test(suiteName = AcceptanceTest.SUITE)
+public class EmbeddedRepeatTest extends SitebricksJettyAcceptanceTest {
+
+    public void shouldRenderPassedParameterInEveryItem() {
+        WebDriver driver = AcceptanceTest.createWebDriver();
+        EmbeddedRepeatPage page = EmbeddedRepeatPage.open(driver);
+        List<String> items = page.getItems();
+        assert items.size() == 3;
+        assert "first item".equals(items.get(0));
+        assert "second item".equals(items.get(1));
+        assert "third item".equals(items.get(2));
+    }
+
+}

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/EmbeddedRepeatPage.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/EmbeddedRepeatPage.java
@@ -1,0 +1,36 @@
+package com.google.sitebricks.acceptance.page;
+
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+public class EmbeddedRepeatPage {
+
+    private final List<WebElement> elements;
+
+    public EmbeddedRepeatPage(WebDriver driver) {
+        elements = driver.findElements(By.xpath("//li[@class='item']"));
+    }
+
+    public List<String> getItems() {
+        List<String> items = new ArrayList<String>();
+        for (WebElement e : elements) {
+            items.add(e.getText());
+        }
+        return items;
+    }
+
+    public static EmbeddedRepeatPage open(WebDriver driver) {
+        driver.get(AcceptanceTest.baseUrl() + "/embedded-repeat");
+        return PageFactory.initElements(driver, EmbeddedRepeatPage.class);
+    }
+
+}

--- a/sitebricks/src/main/java/com/google/sitebricks/rendering/control/RepeatWidget.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/rendering/control/RepeatWidget.java
@@ -77,7 +77,7 @@ class RepeatWidget implements Renderable {
 
             //decorate with some context
             context.put(var, thing);
-            context.put(pageVar, respond.pageObject());
+            context.put(pageVar, bound);
             context.put("index", i++);
             context.put("isLast", i == items.size());
             widgetChain.render(context, respond);


### PR DESCRIPTION
This fix corrects the incorrect behavior when a "brick" (a class with `@EmbedAs` annotation) inside itself uses a `@Repeat` widget to iterate through some sort of collection: the MVEL compiler complains about non-existing properties of the `__page` (or some overridden symbol in the `pageVar` of the `@Repeat` widget) and throws an exception.

Attached acceptance tests that illustrate the issue.
