### PR TITLE
FIX: @EmbedAs widget loses pageVar inside a @Repeat loop

### DIFF
--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/EmbeddedRepeat.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/EmbeddedRepeat.java
@@ -1,0 +1,13 @@
+package com.google.sitebricks.example;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+public class EmbeddedRepeat {
+
+    private final String title = "Page host for an embedded widget";
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/SitebricksConfig.java
@@ -154,6 +154,9 @@ public class SitebricksConfig extends GuiceServletContextListener {
 
         at("/decorated-repeat").show(DecoratedRepeat.class);
 
+        at("/embedded-repeat").show(EmbeddedRepeat.class);
+        embed(WorldAtlas.class).as("WorldAtlas");
+
         at("/jsp").show(Jsp.class);
 
         embed(HelloWorld.class).as("Hello");

--- a/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/WorldAtlas.java
+++ b/sitebricks-acceptance-tests/src/main/java/com/google/sitebricks/example/WorldAtlas.java
@@ -1,0 +1,63 @@
+package com.google.sitebricks.example;
+
+import com.google.sitebricks.rendering.EmbedAs;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@EmbedAs("WorldAtlas")
+public class WorldAtlas {
+
+    private static final List<Continent> CONTINENTS = Arrays.asList(Continent.EUROPE, Continent.ASIA, Continent.NORTH_AMERICA);
+
+    private String continentPrefix;
+    private String countryPrefix;
+
+    public List<Continent> getContinents() {
+        return CONTINENTS;
+    }
+
+    public String getContinentPrefix() {
+        return continentPrefix;
+    }
+
+    public void setContinentPrefix(String suffix) {
+        this.continentPrefix = suffix;
+    }
+
+    public String getCountryPrefix() {
+        return countryPrefix;
+    }
+
+    public void setCountryPrefix(String countryPrefix) {
+        this.countryPrefix = countryPrefix;
+    }
+
+    public static enum Continent {
+
+        EUROPE("Europe", Arrays.asList("Germany", "United Kingdom", "France")),
+        ASIA("Asia", Arrays.asList("Japan", "China")),
+        NORTH_AMERICA("North America", Arrays.asList("United States", "Canada"));
+
+
+        private final String name;
+
+        private final List<String> countries;
+
+        Continent(String name, List<String> countries) {
+            this.name = name;
+            this.countries = countries;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getCountries() {
+            return countries;
+        }
+    }
+}

--- a/sitebricks-acceptance-tests/src/main/resources/EmbeddedRepeat.html
+++ b/sitebricks-acceptance-tests/src/main/resources/EmbeddedRepeat.html
@@ -1,0 +1,11 @@
+<html>
+    <body>
+        <div>
+        <h1>${title}</h1>
+
+        @WorldAtlas(continentPrefix="Continent", countryPrefix="Country")
+        <ul />
+        </div>
+
+    </body>
+</html>

--- a/sitebricks-acceptance-tests/src/main/resources/WorldAtlas.html
+++ b/sitebricks-acceptance-tests/src/main/resources/WorldAtlas.html
@@ -1,0 +1,10 @@
+<ul>
+    @Repeat(items=continents, var="it")
+    <li class="continent">
+        <span class="title">${__page.continentPrefix} ${it.name}</span>
+        <ul>
+            @Repeat(items=it.countries, var="c")
+            <li class="country">${__page.countryPrefix} ${c}</li>
+        </ul>
+    </li>
+</ul>

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/EmbeddedRepeatTest.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/EmbeddedRepeatTest.java
@@ -1,0 +1,38 @@
+package com.google.sitebricks.acceptance;
+
+import com.google.sitebricks.acceptance.page.EmbeddedRepeatPage;
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import org.apache.commons.collections.CollectionUtils;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+@Test(suiteName = AcceptanceTest.SUITE)
+public class EmbeddedRepeatTest extends SitebricksJettyAcceptanceTest {
+
+    public void shouldRenderPassedParameterInEveryItem() {
+        List<String> expectedContinents = Arrays.asList("Continent Europe", "Continent Asia", "Continent North America");
+
+        List<String> expectedCountries = Arrays.asList("Country Germany", "Country United Kingdom", "Country France",
+                                                        "Country Japan", "Country China",
+                                                        "Country United States", "Country Canada");
+
+        WebDriver driver = AcceptanceTest.createWebDriver();
+        EmbeddedRepeatPage page = EmbeddedRepeatPage.open(driver);
+
+        List<String> continents = page.getContinents();
+        List<String> countries = page.getCountries();
+
+        assert CollectionUtils.isEqualCollection(expectedContinents, continents)
+                : "Repeated continent names didn't match what was expected";
+        assert CollectionUtils.isEqualCollection(expectedCountries, countries)
+                : "Repeated country names didn't match what was expected";
+
+    }
+
+}

--- a/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/EmbeddedRepeatPage.java
+++ b/sitebricks-acceptance-tests/src/test/java/com/google/sitebricks/acceptance/page/EmbeddedRepeatPage.java
@@ -1,0 +1,48 @@
+package com.google.sitebricks.acceptance.page;
+
+import com.google.sitebricks.acceptance.util.AcceptanceTest;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * author: Martins Barinskis (martins.barinskis@gmail.com)
+ */
+public class EmbeddedRepeatPage {
+
+    private final List<WebElement> continents;
+
+    private final List<WebElement> countries;
+
+    public EmbeddedRepeatPage(WebDriver driver) {
+        continents = driver.findElements(By.xpath("//li[@class='continent']/span[@class='title']"));
+
+        countries = driver.findElements(By.xpath("//li[@class='country']"));
+    }
+
+    public List<String> getContinents() {
+        return extractStrings(continents);
+    }
+
+    public List<String> getCountries() {
+        return extractStrings(countries);
+    }
+
+    private static List<String> extractStrings(List<WebElement> continents1) {
+        List<String> items = new ArrayList<String>();
+        for (WebElement e : continents1) {
+            items.add(e.getText());
+        }
+        return items;
+    }
+
+    public static EmbeddedRepeatPage open(WebDriver driver) {
+        driver.get(AcceptanceTest.baseUrl() + "/embedded-repeat");
+        return PageFactory.initElements(driver, EmbeddedRepeatPage.class);
+    }
+
+}

--- a/sitebricks/src/main/java/com/google/sitebricks/rendering/control/EmbedWidget.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/rendering/control/EmbedWidget.java
@@ -53,8 +53,8 @@ class EmbedWidget implements Renderable {
       evaluator.write(entry.getKey(), pageObject, evaluator.evaluate(entry.getValue(), bound));
     }
 
-    //chain to embedded page (widget), with arguments
-    EmbeddedRespond embed = factory.get(arguments);
+    //chain to embedded page (widget), with arguments and the parent context
+    EmbeddedRespond embed = factory.get(arguments, pageObject);
 
     Request req = request.get();
     try {

--- a/sitebricks/src/main/java/com/google/sitebricks/rendering/control/EmbeddedRespondFactory.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/rendering/control/EmbeddedRespondFactory.java
@@ -10,9 +10,8 @@ import java.util.Map;
  * @author Dhanji R. Prasanna (dhanji@gmail com)
  */
 @Immutable class EmbeddedRespondFactory {
-  private final Respond respond = new StringBuilderRespond(new Object());
-
-  public EmbeddedRespond get(Map<String, ArgumentWidget> arguments) {
+  public EmbeddedRespond get(Map<String, ArgumentWidget> arguments, Object parentContext) {
+    Respond respond = new StringBuilderRespond(parentContext != null ? parentContext : new Object());
     return new EmbeddedRespond(arguments, respond);
   }
 }

--- a/sitebricks/src/test/java/com/google/sitebricks/rendering/control/EmbeddedRespondExtractorTest.java
+++ b/sitebricks/src/test/java/com/google/sitebricks/rendering/control/EmbeddedRespondExtractorTest.java
@@ -121,7 +121,7 @@ public class EmbeddedRespondExtractorTest {
     public final void extractInsideHeadTags(final String htmlDoc, String expectedHead, String expectedBody) {
         final EmbeddedRespondFactory factory = Guice.createInjector().getInstance(EmbeddedRespondFactory.class);
 
-        final EmbeddedRespond respond = factory.get(Collections.<String, ArgumentWidget>emptyMap());
+        final EmbeddedRespond respond = factory.get(Collections.<String, ArgumentWidget>emptyMap(), new Object());
 
         respond.write(htmlDoc);
 


### PR DESCRIPTION
This PR fixes a problem when MVEL compiler throws an Exception if user references the assigned pageVar object from a @Repeat widget inside an @EmbedAs widget.

Now we pass an additional "parentContext" argument to the EmbeddedRespondFactory, which before was creating a StringBuilderRespond with an empty Object instead.

I have attached acceptance tests to demonstrate the issue, including a nested @Repeat loop case as well.
