### PR TITLE
configurePreFilters() is defined twice in the Javadoc example

### DIFF
--- a/sitebricks/src/main/java/com/google/sitebricks/SitebricksServletModule.java
+++ b/sitebricks/src/main/java/com/google/sitebricks/SitebricksServletModule.java
@@ -21,7 +21,7 @@ import com.google.inject.servlet.ServletModule;
           }
 
           @Override
-          protected void configurePreFilters() {
+          protected void configurePostFilters() {
             filter("/*").through(MyPostFilter.class);
           }
 


### PR DESCRIPTION
I was playing around with sitebricks and came across a Javadoc error. Thought I'd fix it.

Thanks,
-Roman
