### PR TITLE
rest: match paths using regexp

### DIFF
--- a/sitebricks/pom.xml
+++ b/sitebricks/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <classifier>jdk15</classifier>
+      <version>6.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sitebricks/src/test/java/com/google/sitebricks/routing/PathMatcherTest.java
+++ b/sitebricks/src/test/java/com/google/sitebricks/routing/PathMatcherTest.java
@@ -76,6 +76,12 @@ public class PathMatcherTest {
                 put("title", "sokdoasd");
                 put("id", "aoskpaokda");
             }}, },
+            {"/wiki/:id{\\d+}", "/wiki/123", new HashMap() {{
+                put("id", "123");
+            }},},
+            {"/wiki/:id{[a-z]+}", "/wiki/hello", new HashMap() {{
+                put("id", "hello");
+            }},},
         };
     }
 


### PR DESCRIPTION
Adds regex pattern matching on paths, so path variables could be more
complex that are now.

Here are some examples

```
/r/users/:id{\d+}
```

will match only

```
/r/users/123
```

but not

```
/r/users/john
```

Note: testng version was updated in pom.xml due issue with latest Intellij IDEA 15. If this change is breakable, the pom.xml changes will be reverted. 
